### PR TITLE
Add GitHub templates, Claude commands, and CI workflow

### DIFF
--- a/.claude/commands/.markdownlint-cli2.yaml
+++ b/.claude/commands/.markdownlint-cli2.yaml
@@ -1,0 +1,6 @@
+config:
+  first-line-heading: false
+  ul-indent:
+    indent: 4
+  no-inline-html: false
+  blanks-around-fences: false

--- a/.claude/commands/issue-checkout.md
+++ b/.claude/commands/issue-checkout.md
@@ -1,0 +1,228 @@
+# Issue Checkout Command
+
+Check out or create a branch for a GitHub issue and provide context for the work.
+
+## Arguments: $ARGUMENTS
+
+## Instructions
+
+### 1. Check for Clean Working Tree
+
+Before doing anything, ensure there are no uncommitted changes:
+
+```bash
+git status --short
+```
+
+If there are uncommitted changes, **stop and warn the user**:
+
+- Show the list of modified/untracked files
+- Ask using AskUserQuestion:
+    - Question: "You have uncommitted changes. How would you like to proceed?"
+    - Header: "Uncommitted"
+    - Options:
+        - "Commit changes first" - let the user commit before continuing
+        - "Stash changes" - runs `git stash push -m "WIP before switching to issue #<number>"`
+        - "Cancel" - abort the checkout
+
+**Do not proceed** until the working tree is clean or changes are stashed.
+
+### 2. Parse Issue Number
+
+**If arguments are provided**: Extract the GitHub issue number from `$ARGUMENTS`.
+
+- Accept formats: `#91`, `91`, or a full URL like `https://github.com/owner/repo/issues/91`
+- Normalize to just the number
+
+**If arguments are empty**: Ask the user for the issue number using AskUserQuestion:
+
+- Question: "Which issue do you want to work on?"
+- Header: "Issue"
+- Options: Provide a few recent open issues if available, or allow free-form input
+
+### 3. Fetch GitHub Issue Details
+
+Retrieve the issue details:
+
+```bash
+gh issue view <number> --repo knight-owl-dev/devops --json number,title,state,body,labels,assignees
+```
+
+Extract and note:
+
+- Number
+- Title
+- State (OPEN, CLOSED)
+- Labels (bug, enhancement, etc.)
+- Body (description)
+- Assignees
+
+### 4. Check for Existing Branch
+
+Search for any existing branch that matches the issue number:
+
+```bash
+# Check local branches
+git branch --list "<number>-*"
+
+# Check remote branches
+git branch -r --list "origin/<number>-*"
+```
+
+### 5a. Existing Branch Found
+
+If a branch exists:
+
+1. **Check out the branch**:
+
+   ```bash
+   git checkout <existing-branch-name>
+   ```
+
+2. **Review recent work** on this branch:
+
+   ```bash
+   # Show commits on this branch not in main
+   git log main..HEAD --oneline
+
+   # Show uncommitted changes
+   git status --short
+
+   # Show recent file changes
+   git diff --stat main..HEAD
+   ```
+
+3. **Present context to user**:
+    - Summarize the GitHub issue (title, state, description)
+    - Show what commits have been made on this branch
+    - Show any uncommitted work in progress
+    - Suggest next steps based on the current state
+
+4. **Offer to rebase** (optional, only if branch is behind main):
+
+   Check if main has new commits:
+
+   ```bash
+   git fetch origin main
+   git log HEAD..origin/main --oneline
+   ```
+
+   If main has moved ahead, ask the user using AskUserQuestion:
+
+    - Question: "Main has new commits. Would you like to rebase your branch?"
+    - Header: "Rebase"
+    - Options:
+        - "Yes, rebase now" - runs `git pull --rebase origin main`
+        - "No, I'll handle it later" - continues without rebasing
+
+   **Do not rebase automatically** - let the user decide when to deal with potential conflicts.
+
+### 5b. No Existing Branch
+
+If no branch exists:
+
+1. **Ensure on main** and up to date:
+
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
+
+2. **Generate branch name** from issue number and title:
+    - Format: `<issue-number>-<title-slug>`
+    - Slug rules: lowercase, hyphens for spaces, remove special chars, max ~50 chars
+    - Example: `91-add-issue-checkout-command`
+
+3. **Create and check out the branch**:
+
+   ```bash
+   git checkout -b <issue-number>-<title-slug>
+   ```
+
+4. **Present full issue context to user**:
+    - Display the complete GitHub issue details (title, description, labels)
+    - Suggest entering plan mode to design the implementation approach
+
+### 6. Suggest Next Steps
+
+**For existing branch with commits**:
+
+```text
+You're continuing work on issue #91.
+
+Branch: 91-add-issue-checkout-command
+Commits: 3 commits ahead of main
+State: OPEN
+
+Recent commits:
+- abc1234 Add checkout logic
+- def5678 Create command structure
+- ghi9012 Initial implementation
+
+Labels: enhancement
+
+Suggested next steps:
+1. Review any recent changes or feedback
+2. Continue implementation
+```
+
+**For existing branch with no commits**:
+
+```text
+You have an empty branch for issue #91.
+
+Branch: 91-add-issue-checkout-command
+Commits: 0 commits (branch just created or reset)
+
+Issue title: Add issue checkout command
+State: OPEN
+
+Suggested next steps:
+1. Review the issue details below
+2. Consider using /plan to design the implementation
+```
+
+**For new branch**:
+
+```text
+Created new branch for issue #91.
+
+Branch: 91-add-issue-checkout-command
+Based on: main (up to date)
+
+## Issue Details
+
+**Title**: Add issue checkout command for streamlined issue workflow
+**State**: OPEN
+**Labels**: enhancement
+
+**Description**:
+[Full description from GitHub issue]
+
+Suggested next steps:
+1. Review the issue details above
+2. Use /plan to design the implementation approach
+3. Break down into smaller commits as you work
+```
+
+### 7. Assign Issue (Optional)
+
+If the issue has no assignee, offer to self-assign:
+
+- Question: "This issue is unassigned. Assign it to yourself?"
+- Header: "Assign"
+- Options:
+    - "Yes, assign to me" - assigns the issue
+    - "No, leave unassigned" - continues without assigning
+- If yes:
+
+  ```bash
+  gh issue edit <number> --repo knight-owl-dev/devops --add-assignee @me
+  ```
+
+### Error Handling
+
+- **Issue not found**: Inform user the issue doesn't exist
+- **No network/auth**: Remind user to check `gh auth status`
+- **Uncommitted changes on current branch**: Handled in step 1 - must resolve before proceeding
+- **Branch conflicts**: If local and remote branches differ, explain and offer options

--- a/.claude/commands/issue-comment.md
+++ b/.claude/commands/issue-comment.md
@@ -1,0 +1,200 @@
+# Issue Comment Command
+
+Post a comment to a GitHub issue with optional context about your progress.
+
+## Arguments: $ARGUMENTS
+
+## Instructions
+
+### 1. Determine Issue Number
+
+**Priority order for finding the issue number:**
+
+1. **From arguments**: If `$ARGUMENTS` contains an issue number (formats: `#93`, `93`, or URL), use it
+2. **From current branch**: If on a branch matching `<number>-*` pattern, extract the issue number
+3. **Ask the user**: Prompt for the issue number
+
+**If extracting from branch:**
+
+```bash
+git branch --show-current
+```
+
+Parse the branch name (e.g., `93-add-issue-comment-command` → issue #93).
+
+**If asking the user**: Use AskUserQuestion:
+
+- Question: "Which issue do you want to comment on?"
+- Header: "Issue"
+- Options: Show recent open issues assigned to the user, or allow free-form input
+
+### 2. Fetch Issue Context
+
+Retrieve the issue details and comments in a single call:
+
+```bash
+gh issue view <number> --repo knight-owl-dev/devops --json number,title,state,body,labels,comments
+```
+
+The `comments` field returns an array of all comments (gh does not support limiting comment count like Jira).
+
+To get the last few comments in human-readable format:
+
+```bash
+gh issue view <number> --repo knight-owl-dev/devops --comments
+```
+
+Display a brief summary to the user:
+
+- Issue title and state
+- Number of existing comments (from JSON: `.comments | length`)
+- Last comment preview (if any)
+
+### 3. Determine Comment Type
+
+Ask the user what kind of comment they want to post using AskUserQuestion:
+
+- Question: "What type of comment would you like to post?"
+- Header: "Comment"
+- Options:
+    - **"Simple comment"** — Just a text message
+    - **"Progress update"** — Include recent commits and changed files as context
+    - **"Save thoughts"** — Save notes/thoughts for later work on this issue
+
+### 4a. Simple Comment
+
+If the user chose "Simple comment":
+
+**If `$ARGUMENTS` contains text beyond the issue number**: Use that as the comment body.
+
+**Otherwise**: Ask for the comment using AskUserQuestion:
+
+- Question: "What would you like to say?"
+- Header: "Message"
+- Options: Provide a few quick responses, but primarily expect free-form "Other" input
+    - "Looks good, merging soon"
+    - "Need more context on this"
+    - "Working on this now"
+
+### 4b. Progress Update
+
+If the user chose "Progress update":
+
+1. **Gather git context** (only if on an issue branch):
+
+   ```bash
+   # Get commits on this branch not in main
+   git log main..HEAD --oneline
+
+   # Get changed files summary
+   git diff --stat main..HEAD
+
+   # Check for uncommitted work
+   git status --short
+   ```
+
+2. **Ask for a summary** using AskUserQuestion:
+    - Question: "Summarize your progress on this issue:"
+    - Header: "Summary"
+    - Options: Allow free-form input via "Other"
+        - "Implementation complete, ready for review"
+        - "Work in progress, blocked on..."
+        - "Started investigation"
+
+3. **Format the comment** as a structured progress update:
+
+   ```markdown
+   ## Progress Update
+
+   <user's summary>
+
+   ### Commits
+   - `abc1234` First commit message
+   - `def5678` Second commit message
+
+   ### Changed Files
+   - `src/file1.cs` (+50, -10)
+   - `src/file2.cs` (+20, -5)
+
+   ### Status
+   - [ ] Ready for review
+   - [x] Work in progress
+   ```
+
+   Adjust the status checkboxes based on user's summary (e.g., if they said "ready for review", check that box).
+
+### 4c. Save Thoughts
+
+If the user chose "Save thoughts":
+
+1. **Ask for thoughts** using AskUserQuestion:
+    - Question: "What thoughts or notes do you want to save for later?"
+    - Header: "Notes"
+    - Options: Allow free-form input via "Other"
+        - "Need to investigate X before proceeding"
+        - "Consider alternative approach using Y"
+        - "Remember to update tests for Z"
+
+2. **Format as a collapsible note**:
+
+   ```markdown
+   <details>
+   <summary>Dev Notes — <current date in YYYY-MM-DD format></summary>
+
+   <user's thoughts>
+
+   **Current branch:** `93-add-issue-comment-command`
+   **Last commit:** `abc1234 — commit message`
+
+   </details>
+   ```
+
+### 5. Preview and Confirm
+
+Before posting, show the user a preview of the full comment.
+
+Ask using AskUserQuestion:
+
+- Question: "Post this comment to issue #<number>?"
+- Header: "Confirm"
+- Options:
+    - "Post comment" — proceed with posting
+    - "Edit first" — let the user modify (go back to comment input)
+    - "Cancel" — abort without posting
+
+### 6. Post the Comment
+
+Use the gh CLI to post the comment:
+
+```bash
+gh issue comment <number> --repo knight-owl-dev/devops --body "<comment-body>"
+```
+
+Use a HEREDOC for multi-line comments:
+
+```bash
+gh issue comment <number> --repo knight-owl-dev/devops --body "$(cat <<'EOF'
+<comment-body>
+EOF
+)"
+```
+
+### 7. Confirmation
+
+After successful posting:
+
+- Display "Comment posted to issue #<number>"
+- Show the issue URL: `https://github.com/knight-owl-dev/devops/issues/<number>`
+- Offer to open in browser:
+
+  ```bash
+  gh issue view <number> --repo knight-owl-dev/devops --web
+  ```
+
+### Error Handling
+
+- **Issue not found**: Inform user the issue doesn't exist
+- **No network/auth**: Remind user to check `gh auth status`
+- **Empty comment**: Do not allow posting empty comments
+- **Not on issue branch**: If a progress update is selected but the current branch does not match an issue pattern, fall
+  back to a simple comment and inform the user: "Note: No issue branch detected; git context will not be included."

--- a/.claude/commands/issue-create.md
+++ b/.claude/commands/issue-create.md
@@ -1,0 +1,157 @@
+# GitHub Issue Creation Command
+
+Create a new GitHub issue following project templates.
+
+## Arguments: $ARGUMENTS
+
+## Instructions
+
+### 1. Gather Issue Description
+
+**If arguments are provided**: Use `$ARGUMENTS` as the issue description.
+
+**If arguments are empty**: Ask the user to describe the issue using AskUserQuestion:
+
+- Question: "What would you like to create an issue for?"
+- Header: "Description"
+- Options: Provide 2-3 example categories as options (e.g., "Bug report", "New feature",
+  "Documentation update") but allow free-form input via "Other"
+
+### 2. Determine Issue Type
+
+Analyze the description to determine whether this is a **bug** or **task/enhancement**:
+
+**Bug indicators**:
+
+- Words like: broken, not working, error, crash, fail, unexpected, wrong, regression
+- Describes something that was working before
+- Reports incorrect behavior vs expected behavior
+
+**Task/Enhancement indicators**:
+
+- Words like: add, implement, create, improve, update, refactor, enable, support
+- Describes new functionality or improvements
+- Focuses on goals and outcomes
+
+### 3. Suggest Labels
+
+Based on the description, recommend applicable labels from this list:
+
+| Label              | When to suggest                                |
+|--------------------|------------------------------------------------|
+| `bug`              | Something is broken or not working as expected |
+| `enhancement`      | New feature, improvement, or planned work      |
+| `documentation`    | Documentation-only changes                     |
+| `security`         | Security-related fixes or improvements         |
+| `breaking-change`  | Changes that break existing behavior           |
+| `dependencies`     | Dependency updates                             |
+| `good-first-issue` | Simple issues suitable for newcomers           |
+| `help-wanted`      | Issues needing extra attention or expertise    |
+
+Always suggest at least one primary label (`bug`, `enhancement`, or `documentation`).
+
+### 4. Confirm with User
+
+Use AskUserQuestion to confirm the issue type and labels:
+
+- Show the determined issue type (Bug or Task/Enhancement)
+- Show the recommended labels
+- Allow the user to adjust before proceeding
+
+### 5. Draft Issue Content
+
+Based on the confirmed type, draft the issue following the appropriate template.
+
+**Formatting**: Write paragraphs as flowing text without hard line breaks. GitHub's
+markdown renderer handles wrapping automatically. Only use line breaks between sections
+or for bullet lists.
+
+**For Bug Reports** (template: `.github/ISSUE_TEMPLATE/bug.md`):
+
+```markdown
+## What happened
+
+[Extract from description: the observed behavior]
+
+## What was expected
+
+[Infer or ask: what should have happened]
+
+## Steps to reproduce
+
+[If provided, otherwise mark as "To be determined"]
+
+## Environment
+
+[If provided, otherwise mark as "To be determined"]
+
+## Notes
+
+[Any additional context from the description]
+```
+
+**For Tasks/Enhancements** (template: `.github/ISSUE_TEMPLATE/task.md`):
+
+```markdown
+## Goal
+
+[Extract from description: the outcome being achieved]
+
+## Scope
+
+- [Break down into high-level bullets]
+- [Focus on what is included]
+- [Avoid implementation details]
+
+## Outcome
+
+[What will be improved, clearer, safer, faster, or more reliable]
+
+## Notes
+
+[Any additional context, constraints, or links]
+```
+
+### 6. Generate Issue Title
+
+Create a clear, concise title that:
+
+- Is outcome-focused (describes what will be achieved or fixed)
+- Uses imperative mood for tasks ("Add...", "Enable...", "Update...")
+- Uses descriptive mood for bugs ("Fix...", "Resolve...")
+- Is 50-72 characters when possible
+
+### 7. Preview and Confirm
+
+Show the user a preview of:
+
+- Title
+- Labels
+- Body content
+
+Ask for confirmation before creating.
+
+### 8. Create the Issue
+
+Use the gh CLI to create the issue:
+
+```bash
+gh issue create \
+  --repo knight-owl-dev/devops \
+  --label "<labels>" \
+  --title "<title>" \
+  --body "<body>"
+```
+
+### 9. Output
+
+After successful creation:
+
+- Display the issue URL
+- Note that Issue Types must be set manually (gh CLI doesn't support this yet)
+- Ask if the user wants to open the issue in browser to set the type:
+  ```bash
+  gh issue view <issue-number> --repo knight-owl-dev/devops --web
+  ```
+- Offer to create a branch for the issue (using GitHub's naming convention:
+  `<issue-number>-<issue-title-slug>`)

--- a/.claude/commands/pr-create.md
+++ b/.claude/commands/pr-create.md
@@ -1,0 +1,234 @@
+# Pull Request Creation Command
+
+Create a pull request following the project's PR template and conventions.
+
+This command supports both **cloned** repositories (direct push access) and **forked**
+repositories (contributor forks).
+
+## Arguments: $ARGUMENTS
+
+## Instructions
+
+### 1. Gather Context
+
+Run these commands in parallel to gather context:
+
+```bash
+# Get current branch name
+git branch --show-current
+
+# Get commits on this branch (since diverging from main)
+git log main..HEAD --oneline
+
+# Check for uncommitted changes
+git status --short
+
+# Check repository fork status and get parent info
+gh repo view --json isFork,parent,nameWithOwner
+```
+
+### 2. Determine Repository Topology
+
+Analyze the `gh repo view` output to determine the workflow type:
+
+**Cloned repository (direct access):**
+
+```json
+{
+  "isFork": false,
+  "nameWithOwner": "knight-owl-dev/devops",
+  "parent": null
+}
+```
+
+**Forked repository (contributor fork):**
+
+```json
+{
+  "isFork": true,
+  "nameWithOwner": "alice/devops",
+  "parent": {
+    "name": "devops",
+    "owner": { "login": "knight-owl-dev" }
+  }
+}
+```
+
+Store these values for later steps:
+
+- `is_fork`: boolean from `isFork`
+- `fork_owner`: extract from `nameWithOwner` (e.g., "alice" from "alice/devops")
+- `upstream_repo`: if fork, use `parent.owner.login/parent.name`; otherwise use `nameWithOwner`
+
+### 3. Extract Issue Reference
+
+Parse the branch name to extract the issue number:
+
+- Branch format: `<issue-number>-<title-slug>` (e.g.,
+  `31-add-claude-code-command-for-creating-pull-requests-via-gh-cli`)
+- Extract the leading number as the issue reference
+- If no issue number is found, ask the user if this PR relates to an issue
+
+### 4. Fetch Issue Details
+
+If an issue number was found, fetch the issue to understand the scope:
+
+```bash
+gh issue view <issue-number> --repo knight-owl-dev/devops
+```
+
+Use the issue's Goal, Scope, and context to inform the PR summary.
+
+### 5. Analyze Commits
+
+Review the git log output to understand what changes were made:
+
+- Group related commits conceptually
+- Identify the high-level changes (not commit-by-commit detail)
+- Focus on what behavior/functionality changed
+
+### 6. Determine Labels
+
+Based on the issue labels and commit content, recommend applicable labels:
+
+| Label             | When to suggest                        |
+|-------------------|----------------------------------------|
+| `bug`             | Fixes something broken                 |
+| `enhancement`     | New feature or improvement             |
+| `documentation`   | Documentation-only changes             |
+| `security`        | Security-related fixes or improvements |
+| `breaking-change` | Changes that break existing behavior   |
+| `dependencies`    | Dependency updates                     |
+
+If the related issue has labels, prefer to match them.
+
+### 7. Draft PR Content
+
+Follow the PR template (`.github/pull_request_template.md`):
+
+**Formatting**: Write paragraphs as flowing text without hard line breaks. GitHub's
+markdown renderer handles wrapping automatically. Only use line breaks between sections
+or for bullet lists.
+
+```markdown
+## Summary
+
+[Describe the outcome this PR delivers, derived from the issue's Goal.
+Focus on the WHY, not the HOW. Use flowing prose, not bullets.]
+
+## Related Issues
+
+[Use "Refs #NN" or "Fixes #NN" based on whether PR fully completes the issue]
+
+Refs #<issue-number>
+
+## Changes
+
+[High-level bullets derived from analyzing commits. Avoid commit-level detail.
+Group related changes conceptually.]
+
+- [Change 1]
+- [Change 2]
+- [Change 3]
+
+## Further Comments
+
+[Optional: testing notes, migration steps, or anything reviewers should know.
+Omit this section if not needed.]
+```
+
+### 8. Generate PR Title
+
+Create an outcome-focused title that:
+
+- Describes what the PR achieves (not what it does)
+- Uses imperative mood ("Add...", "Enable...", "Fix...")
+- Matches the issue title style when applicable
+- Is concise (50-72 characters preferred)
+- **Does NOT include issue references** (e.g., avoid `Fix bug (#42)`)—GitHub automatically
+  appends the PR number during squash merge; issue linking belongs in the body via `Refs #NN`
+  or `Fixes #NN`
+
+### 9. Preview and Confirm
+
+Show the user a preview of:
+
+- Title
+- Labels
+- Full body content
+
+Use AskUserQuestion to confirm before creating, with options to:
+
+- Create the PR as shown
+- Edit the title
+- Edit the content
+- Add/remove labels
+
+### 10. Push Branch if Needed
+
+Check if the branch has been pushed to remote:
+
+```bash
+git status -sb
+```
+
+If not pushed (no upstream), push with tracking:
+
+```bash
+git push -u origin <branch-name>
+```
+
+This works for both workflows:
+
+- **Clone**: `origin` is the main repository
+- **Fork**: `origin` is the user's fork (correct destination for PR branches)
+
+### 11. Create the Pull Request
+
+Use gh CLI to create the PR. The `--head` flag format differs based on repository topology.
+
+**For cloned repositories** (direct access):
+
+```bash
+gh pr create \
+  --repo knight-owl-dev/devops \
+  --base main \
+  --head <branch-name> \
+  --label "<labels>" \
+  --title "<title>" \
+  --body "<body>"
+```
+
+**For forked repositories** (contributor fork):
+
+```bash
+gh pr create \
+  --repo knight-owl-dev/devops \
+  --base main \
+  --head <fork-owner>:<branch-name> \
+  --label "<labels>" \
+  --title "<title>" \
+  --body "<body>"
+```
+
+The `--head` flag must include the fork owner prefix (e.g., `alice:my-feature-branch`) so
+GitHub knows which fork contains the branch.
+
+### 12. Output
+
+After successful creation:
+
+- Display the PR URL
+- Ask if the user wants to open it in browser:
+  ```bash
+  gh pr view <pr-number> --repo knight-owl-dev/devops --web
+  ```
+
+### Error Handling
+
+- **Uncommitted changes**: Warn the user and ask if they want to commit first
+- **No commits**: Inform user there are no changes to create a PR for
+- **Branch not pushed**: Offer to push the branch automatically
+- **PR already exists**: Show the existing PR URL instead
+- **Fork not synced**: If the fork's main branch is behind upstream, suggest syncing first
+- **Head reference not found**: Likely missing fork owner prefix. Verify topology detection

--- a/.github/.markdownlint-cli2.yaml
+++ b/.github/.markdownlint-cli2.yaml
@@ -1,0 +1,2 @@
+config:
+  first-line-heading: false

--- a/.github/ISSUE_TEMPLATE/.markdownlint-cli2.yaml
+++ b/.github/ISSUE_TEMPLATE/.markdownlint-cli2.yaml
@@ -1,0 +1,2 @@
+config:
+  first-line-heading: false

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Something is not working as expected
+labels: bug
+---
+
+## What happened
+
+<!--
+Describe the observed behavior.
+-->
+
+## What was expected
+
+<!--
+Describe what you expected to happen.
+-->
+
+## Steps to reproduce
+
+<!--
+Minimal steps, if known.
+-->
+
+## Environment
+
+<!--
+OS, version, CLI version, or other relevant context.
+-->
+
+## Notes
+
+<!--
+Optional additional context.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,35 @@
+---
+name: Task / Enhancement
+about: Planned work, improvements, or operational tasks
+labels: enhancement
+---
+
+## Goal
+
+<!--
+What outcome are we trying to achieve?
+Focus on intent, not implementation.
+-->
+
+## Scope
+
+<!--
+High-level bullets describing what is included.
+Avoid premature technical detail.
+-->
+
+-
+-
+-
+
+## Outcome
+
+<!--
+What will be clearer, safer, faster, or more reliable once this is done?
+-->
+
+## Notes
+
+<!--
+Optional context, constraints, or links.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+<!--
+PR workflow reminder:
+- Use a clear, outcome-focused title (this becomes a release note entry)
+- Do NOT include issue numbers in the title — GitHub appends the PR number on squash merge
+- Apply appropriate labels (e.g. enhancement, documentation, bug)
+- Use special labels (`breaking-change`, `security`, `dependencies`) intentionally — they affect release notes
+- Reference related issues in the description using `Refs #NN` or `Fixes #NN`
+- Squash merge is preferred unless stated otherwise
+-->
+
+## Summary
+
+<!--
+Briefly describe *what outcome this PR delivers*.
+Think in terms of behavior, workflow, or guarantees — not implementation steps.
+Explain the **WHY**, not the **HOW**.
+-->
+
+## Related Issues
+
+<!--
+Use one of:
+- Refs #NN  (contributes to an issue, prefer to close the issue manually if finished)
+- Fixes #NN (closes an issue on merge)
+-->
+
+Refs #
+
+## Changes
+
+<!--
+High-level bullets only. Avoid commit-level detail.
+Use bullets, not paragraphs.
+-->
+
+-
+-
+-
+
+## Further Comments
+
+<!--
+Optional context: testing notes, migration steps, screenshots, or anything
+reviewers should know that doesn't fit above.
+-->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Read and follow `docs/supply-chain-security.md`. This is non-negotiable. Never i
 - **compose.yaml uses `image:` not `tags:`** to name the built image, avoiding Docker Compose's `<project>-<service>` double-naming.
 - **Hyphenated tool names** (e.g., `markdownlint-cli2`) map to underscored function names (`resolve_markdownlint_cli2`) via `${tool//-/_}` in the resolver dispatch.
 - **shfmt enforces `2> /dev/null`** (with a space before `>`), not `2>/dev/null`.
+- **Do not reference issues in commit messages.** Issue linking (`Refs #NN`, `Fixes #NN`) belongs in the PR description only. Commits should describe what changed, not which issue they relate to.
 
 ## Key docs
 


### PR DESCRIPTION
## Summary

Establish project workflow infrastructure so contributors have consistent templates for issues and PRs, and Claude Code can manage the full issue-to-PR lifecycle via slash commands.

## Related Issues

Fixes #2

## Changes

- PR template with outcome-focused structure and squash-merge conventions
- Issue templates for bug reports and tasks/enhancements
- Claude commands for issue checkout, creation, commenting, and PR creation
- Per-directory markdownlint overrides for templates and command files
- CLAUDE.md gotcha: issue references belong in PRs, not commits