### PR TITLE
Document actionlint explicit-paths caveat for CI containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ jobs:
       - run: make lint
 ```
 
+> **Caveat:** Pass `.github/workflows/*.yml` explicitly to actionlint instead
+> of relying on auto-discovery. Auto-discovery breaks inside CI containers
+> where the workspace path doesn't match what actionlint expects.
+>
+> ```makefile
+> actionlint .github/workflows/*.yml
+> ```
+
 ### Publishing
 
 The image is published automatically when a version tag is pushed. A single


### PR DESCRIPTION
## Summary

Consumers of the ci-tools image need to know that actionlint auto-discovery breaks inside CI containers. This adds a caveat to the README usage section so teams don't hit a confusing failure on their first CI run.

Fixes #4

## Changes

- Add caveat callout to README usage section explaining that `.github/workflows/*.yml` must be passed explicitly to actionlint
- Include a code snippet showing the correct invocation