### PR TITLE
Run ci-tools container as non-root user

### DIFF
--- a/images/ci-tools/Dockerfile
+++ b/images/ci-tools/Dockerfile
@@ -80,3 +80,6 @@ LABEL org.opencontainers.image.authors="Knight Owl LLC"
 LABEL org.opencontainers.image.source="https://github.com/knight-owl-dev/devops"
 LABEL org.opencontainers.image.version="${IMAGE_VERSION}"
 LABEL org.opencontainers.image.description="Shared linting image for Knight Owl CI pipelines"
+
+# ---------- drop privileges (all tools are in system paths, runtime is read-only) ---
+USER node


### PR DESCRIPTION
## Summary

- Add `USER node` directive to the ci-tools Dockerfile, dropping privileges from root to the existing `node` user (uid 1000) from the base image
- All installed tools live in system paths and runtime workloads are read-only, so root is unnecessary
- Satisfies hadolint rule DL3002 ("Last USER should not be root")

Refs #10

## Test plan

- [x] `make build` — image builds successfully
- [x] `make verify` — all tools pass version checks
- [x] `docker run --rm ci-tools:local id` — confirms `uid=1000(node)`
- [x] `make lint` — full lint suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)