### PR TITLE
Revert non-root USER directive from ci-tools image

### DIFF
--- a/images/ci-tools/Dockerfile
+++ b/images/ci-tools/Dockerfile
@@ -80,6 +80,3 @@ LABEL org.opencontainers.image.authors="Knight Owl LLC"
 LABEL org.opencontainers.image.source="https://github.com/knight-owl-dev/devops"
 LABEL org.opencontainers.image.version="${IMAGE_VERSION}"
 LABEL org.opencontainers.image.description="Shared linting image for Knight Owl CI pipelines"
-
-# ---------- drop privileges (all tools are in system paths, runtime is read-only) ---
-USER node


### PR DESCRIPTION
## Summary

- Remove the `USER node` directive added in #11
- GitHub Actions creates workspace and temp directories as root before the container starts, so the non-root user gets `EACCES` errors on `actions/checkout`
- Since this is a CI-only image with ephemeral containers, running as root is standard practice and does not meaningfully increase the attack surface

Fixes #12

## Test plan

- [ ] `make build` — image builds successfully
- [ ] `make verify` — all tools pass version checks
- [ ] `make lint` — full lint suite passes
- [ ] Consumer repo CI passes without `options: --user root`

🤖 Generated with [Claude Code](https://claude.com/claude-code)