### PR TITLE
Use atomic writes for versions.lock in resolve script

### DIFF
--- a/scripts/ci-tools/resolve.sh
+++ b/scripts/ci-tools/resolve.sh
@@ -19,6 +19,10 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${0}")/../.." && pwd)"
 LOCKFILE="${REPO_ROOT}/images/ci-tools/versions.lock"
+LOCKFILE_TMP=""
+
+cleanup() { [[ -n "${LOCKFILE_TMP}" ]] && rm -f "${LOCKFILE_TMP}"; }
+trap cleanup EXIT
 
 # ── helpers ──────────────────────────────────────────────────────────
 
@@ -163,7 +167,8 @@ done
 
 # ── write lockfile ───────────────────────────────────────────────────
 
-cat > "${LOCKFILE}" << EOF
+LOCKFILE_TMP="$(mktemp)"
+cat > "${LOCKFILE_TMP}" << EOF
 SHFMT_VERSION=${SHFMT_VERSION}
 SHFMT_SHA256_AMD64=${SHFMT_SHA256_AMD64}
 SHFMT_SHA256_ARM64=${SHFMT_SHA256_ARM64}
@@ -179,5 +184,6 @@ STYLELINT_VERSION=${STYLELINT_VERSION}
 LUACHECK_VERSION=${LUACHECK_VERSION}
 VALIDATE_ACTION_PINS_VERSION=${VALIDATE_ACTION_PINS_VERSION}
 EOF
+mv "${LOCKFILE_TMP}" "${LOCKFILE}"
 
 echo "OK: lockfile written to ${LOCKFILE}"


### PR DESCRIPTION
## Summary

Prevents a truncated or partially written `versions.lock` if the resolve script exits mid-run. The lockfile is now written to a temp file first and atomically moved into place on success, with a cleanup trap that removes the temp file on early exit.

## Related Issues

Fixes #23

## Changes

- Write lockfile content to a temp file instead of directly to `versions.lock`
- Atomically `mv` the temp file into place after a successful write
- Register an `EXIT` trap to clean up the temp file on script failure