### PR TITLE
Chain Makefile lint commands for explicit success output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,48 +37,32 @@ lint-fix: lint-sh-fmt-fix lint-md-fix
 
 # Lint Dockerfiles
 lint-docker:
-	@echo "Linting Dockerfiles..."
-	@hadolint images/*/Dockerfile
-	@echo "OK"
+	@echo "Linting Dockerfiles..." && hadolint images/*/Dockerfile && echo "OK"
 
 # Lint shell scripts
 lint-sh:
-	@echo "Linting shell scripts..."
-	@shellcheck scripts/*/*.sh images/*/bin/*
-	@echo "OK"
+	@echo "Linting shell scripts..." && shellcheck scripts/*/*.sh images/*/bin/* && echo "OK"
 
 # Check shell script formatting
 lint-sh-fmt:
-	@echo "Checking shell script formatting..."
-	@shfmt -d -i 2 -ci -bn -sr scripts/
-	@echo "OK"
+	@echo "Checking shell script formatting..." && shfmt -d -i 2 -ci -bn -sr scripts/ && echo "OK"
 
 # Fix shell script formatting
 lint-sh-fmt-fix:
-	@echo "Fixing shell script formatting..."
-	@shfmt -w -i 2 -ci -bn -sr scripts/
-	@echo "OK"
+	@echo "Fixing shell script formatting..." && shfmt -w -i 2 -ci -bn -sr scripts/ && echo "OK"
 
 # Lint GitHub Actions workflows
 lint-actions:
-	@echo "Linting GitHub Actions..."
-	@actionlint .github/workflows/*.yml
-	@echo "OK"
-	@echo "Validating GitHub Actions pins..."
-	@$(VALIDATE_ACTION_PINS) .github/workflows/*.yml
-	@echo "OK"
+	@echo "Linting GitHub Actions..." && actionlint .github/workflows/*.yml && echo "OK"
+	@echo "Validating GitHub Actions pins..." && $(VALIDATE_ACTION_PINS) .github/workflows/*.yml && echo "OK"
 
 # Lint Markdown files
 lint-md:
-	@echo "Linting Markdown..."
-	@markdownlint-cli2 '**/*.md'
-	@echo "OK"
+	@echo "Linting Markdown..." && markdownlint-cli2 '**/*.md' && echo "OK"
 
 # Fix Markdown files
 lint-md-fix:
-	@echo "Fixing Markdown..."
-	@markdownlint-cli2 --fix '**/*.md'
-	@echo "OK"
+	@echo "Fixing Markdown..." && markdownlint-cli2 --fix '**/*.md' && echo "OK"
 
 # Remove local image
 clean:


### PR DESCRIPTION
## Summary

Lint targets previously relied on Make's recipe-line semantics to avoid printing "OK" after a linter failure. While Make does stop on a failed line, chaining commands with `&&` makes the intent self-evident and removes any ambiguity about output ordering.

## Related Issues

Fixes #21

## Changes

- Chain each lint target's echo, linter invocation, and "OK" message with `&&` so success output is explicitly gated on linter exit code
- Apply the same pattern to fix targets (`lint-sh-fmt-fix`, `lint-md-fix`) for consistency

## Further Comments

Verified that Make's default behavior already stops after a failed recipe line — "OK" did not print on failure before this change either. This PR makes the guarantee explicit rather than implicit, and reduces each target from three shell invocations to one.