### PR TITLE
Document root-user rationale for CI images

### DIFF
--- a/docs/how-to/add-image.md
+++ b/docs/how-to/add-image.md
@@ -43,6 +43,10 @@ mkdir -p images/<name> scripts/<name>
     runtime so the script can read it for `--version`.
   - Place the script in `images/<name>/bin/`.
 
+Images run as root. They target CI runners (GitHub Actions) where the workspace
+is owned by root and consumers would need to escalate anyway. Do not add a
+`USER` directive — it adds friction without meaningful isolation in CI.
+
 ### 3. Create the resolve script
 
 `scripts/<name>/resolve.sh` fetches latest versions (and checksums where

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -54,6 +54,13 @@ locally.
 - **Implicit trust** — no action or dependency gets a pass because it's
   "probably fine." If it runs in CI, it needs a reason to be there.
 
+## Runtime User
+
+Images run as root. They are designed for CI runners (GitHub Actions) where the
+workspace is owned by root and every consumer would need to escalate to root
+regardless. A non-root `USER` directive was tried and reverted (#11, #13)
+because it added friction without meaningful isolation in a CI-only context.
+
 ## Adding New Tools or Images
 
 When adding a tool to an existing image or creating a new image:

--- a/images/ci-tools/Dockerfile
+++ b/images/ci-tools/Dockerfile
@@ -85,6 +85,11 @@ ARG VALIDATE_ACTION_PINS_VERSION
 ENV VALIDATE_ACTION_PINS_VERSION=${VALIDATE_ACTION_PINS_VERSION}
 COPY --chmod=755 bin/validate-action-pins /usr/local/bin/validate-action-pins
 
+# ---------- runtime ----------
+# Images run as root because they target CI runners (GitHub Actions) where the
+# workspace is owned by root. Consumers would need to escalate to root anyway,
+# so a non-root USER directive only adds friction without meaningful isolation.
+
 # ---------- metadata ----------
 ARG IMAGE_VERSION=local
 LABEL maintainer="Knight Owl <support@knight-owl.dev>"


### PR DESCRIPTION
## Summary

Both code reviews flagged the root-user container as a concern. The decision is intentional — images target GitHub Actions runners where the workspace is owned by root and consumers would need to escalate regardless — but the rationale was not documented anywhere. This captures it in three places so future contributors and reviewers understand the convention.

## Related Issues

Fixes #26

## Changes

- Add a runtime comment block in the Dockerfile explaining the root-user decision
- Document the convention in `docs/how-to/add-image.md` as guidance for new images
- Add a "Runtime User" section to `docs/supply-chain-security.md` with references to the original PRs (#11, #13)