### PR TITLE
Add concurrency control to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,9 @@ jobs:
   publish:
     name: Publish ${{ matrix.image }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: publish-${{ matrix.image }}
+      cancel-in-progress: false
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

If two version tags are pushed in quick succession, concurrent publishes of the same image could race — the verify build could read stale registry cache from a concurrent push, or two pushes could overwrite each other's `latest` tag non-deterministically. A concurrency group serializes publishes per image to prevent this.

## Related Issues

Fixes #20

## Changes

- Add a `concurrency` group scoped to `publish-${{ matrix.image }}` on the publish job
- Set `cancel-in-progress: false` so in-flight builds complete rather than being aborted