### PR TITLE
Pin base image to digest

### DIFF
--- a/images/ci-tools/Dockerfile
+++ b/images/ci-tools/Dockerfile
@@ -1,5 +1,5 @@
 # ci-tools — shared linting image for Knight Owl CI pipelines
-FROM node:25-bookworm-slim
+FROM node:25-bookworm-slim@sha256:a0dc7673b38a196909926a308011efe0c380530e0d7a1f1922498c182a3613f4
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION
## Summary

The base image `node:25-bookworm-slim` was pinned to a major version only, meaning upstream patch releases could introduce vulnerabilities or subtle behavior changes without any change on our side. Pinning to a full digest locks all transitive dependencies (apt packages, system libraries) to a known-good state. Dependabot already monitors this directory and will propose digest bumps automatically.

## Related Issues

Fixes #19

## Changes

- Pin `FROM node:25-bookworm-slim` to its current digest in the ci-tools Dockerfile