### PR TITLE
Improve resolve script error messages and output

### DIFF
--- a/scripts/ci-tools/resolve.sh
+++ b/scripts/ci-tools/resolve.sh
@@ -123,17 +123,18 @@ resolve_validate_action_pins() {
 # ── argument parsing ─────────────────────────────────────────────────
 
 # Determine which tools to resolve and whether a version is pinned.
+ALL_TOOLS=(shfmt actionlint hadolint markdownlint-cli2 biome stylelint luacheck validate-action-pins)
 TOOLS_TO_RESOLVE=()
 declare -A PINNED_VERSIONS=()
 
 if [[ $# -eq 0 ]]; then
-  TOOLS_TO_RESOLVE=(shfmt actionlint hadolint markdownlint-cli2 biome stylelint luacheck validate-action-pins)
+  TOOLS_TO_RESOLVE=("${ALL_TOOLS[@]}")
 else
   for arg in "${@}"; do
     tool="${arg%%:*}"
     case "${tool}" in
       shfmt | actionlint | hadolint | markdownlint-cli2 | biome | stylelint | luacheck | validate-action-pins) ;;
-      *) die "unknown tool: ${tool}" ;;
+      *) die "unknown tool: ${tool}. Valid tools: ${ALL_TOOLS[*]}" ;;
     esac
     TOOLS_TO_RESOLVE+=("${tool}")
     if [[ "${arg}" == *:* ]]; then
@@ -161,8 +162,10 @@ fi
 # ── resolve requested tools ──────────────────────────────────────────
 
 for tool in "${TOOLS_TO_RESOLVE[@]}"; do
-  echo "  ..   ${tool}"
   "resolve_${tool//-/_}" "${PINNED_VERSIONS[${tool}]:-}"
+  version_var="${tool^^}"
+  version_var="${version_var//-/_}_VERSION"
+  echo "  OK   ${tool}  ${!version_var}"
 done
 
 # ── write lockfile ───────────────────────────────────────────────────

--- a/scripts/lib/resolve.sh
+++ b/scripts/lib/resolve.sh
@@ -53,7 +53,7 @@ fetch_gh_asset() {
 validate_sha256() {
   local hash="${1}" tool="${2}"
   if [[ ! "${hash}" =~ ^[a-f0-9]{64}$ ]]; then
-    die "invalid SHA256 for ${tool}: ${hash}"
+    die "invalid SHA256 for ${tool}: ${hash:-(empty)}"
   fi
 }
 


### PR DESCRIPTION
## Summary

Resolve script errors now include actionable context — unknown tool errors list valid names, SHA256 validation failures show the actual (or empty) value received, and each tool prints its resolved version on completion instead of a placeholder.

## Related Issues

Refs #25

## Changes

- Show resolved version next to each tool name during resolution instead of a `..` placeholder
- Display `(empty)` in SHA256 validation errors when the hash value is missing
- List valid tool names in the unknown-tool error message
- Extract `ALL_TOOLS` array to single source of truth for tool names

## Further Comments

This addresses the error message and output improvements from #25. The `--verbose` flag for API/auth debugging is left for a follow-up.