### PR TITLE
Add schema validation for versions.lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE_TAG ?= $(IMAGE):local
 # validation toolchain; fall back to the repo copy on bare metal.
 VALIDATE_ACTION_PINS := $(shell command -v validate-action-pins 2>/dev/null || echo images/ci-tools/bin/validate-action-pins)
 
-.PHONY: sync resolve build verify lint lint-fix lint-docker lint-sh lint-sh-fmt lint-sh-fmt-fix lint-actions lint-md lint-md-fix clean help
+.PHONY: sync resolve build verify lint lint-fix lint-lockfile lint-docker lint-sh lint-sh-fmt lint-sh-fmt-fix lint-actions lint-md lint-md-fix clean help
 
 # Resolve latest versions, build, and verify image
 sync: resolve build verify
@@ -30,10 +30,14 @@ verify:
 		$(IMAGE_TAG) bash /scripts/$(IMAGE)/verify.sh
 
 # Run all linters
-lint: lint-docker lint-sh lint-sh-fmt lint-actions lint-md
+lint: lint-lockfile lint-docker lint-sh lint-sh-fmt lint-actions lint-md
 
 # Fix all auto-fixable lint issues
 lint-fix: lint-sh-fmt-fix lint-md-fix
+
+# Validate lockfile keys match Dockerfile ARGs
+lint-lockfile:
+	@echo "Validating lockfile..." && scripts/lib/validate-lockfile.sh $(IMAGE) && echo "OK"
 
 # Lint Dockerfiles
 lint-docker:
@@ -82,6 +86,7 @@ help:
 	@echo "  make clean             Remove local image"
 	@echo "  make lint              Run all linters"
 	@echo "  make lint-actions      Lint GitHub Actions workflows"
+	@echo "  make lint-lockfile     Validate lockfile against Dockerfile"
 	@echo "  make lint-docker       Lint Dockerfiles"
 	@echo "  make lint-fix          Fix all auto-fixable lint issues"
 	@echo "  make lint-md           Lint Markdown files"

--- a/scripts/lib/validate-lockfile.sh
+++ b/scripts/lib/validate-lockfile.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# validate-lockfile.sh — Validate that versions.lock keys match Dockerfile ARGs
+#
+# Extracts bare ARG declarations (no default value) from the Dockerfile,
+# compares them against keys in the lockfile, and reports mismatches in
+# both directions.
+#
+# Usage:
+#   scripts/lib/validate-lockfile.sh <image>
+#
+# Example:
+#   scripts/lib/validate-lockfile.sh ci-tools
+#
+# Exit codes:
+#   0 - Lockfile and Dockerfile ARGs match
+#   1 - One or more mismatches found, or invalid arguments
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# shellcheck source=scripts/lib/resolve.sh
+source "${SCRIPT_DIR}/resolve.sh"
+
+image="${1:-}"
+[[ -n "${image}" ]] || die "usage: validate-lockfile.sh <image>"
+
+dockerfile="${REPO_ROOT}/images/${image}/Dockerfile"
+lockfile="${REPO_ROOT}/images/${image}/versions.lock"
+
+[[ -f "${dockerfile}" ]] || die "Dockerfile not found: ${dockerfile}"
+[[ -f "${lockfile}" ]] || die "lockfile not found: ${lockfile}"
+
+tmpdir="$(mktemp -d)"
+cleanup() { rm -rf "${tmpdir}"; }
+trap cleanup EXIT
+
+# Bare ARG names from Dockerfile (no default value), excluding TARGETARCH.
+sed -n 's/^ARG \([A-Z_][A-Z0-9_]*\)$/\1/p' "${dockerfile}" \
+  | sed '/^TARGETARCH$/d' \
+  | sort > "${tmpdir}/dockerfile"
+
+# Key names from lockfile.
+sed -n 's/^\([A-Z_][A-Z0-9_]*\)=.*/\1/p' "${lockfile}" \
+  | sort > "${tmpdir}/lockfile"
+
+# Find mismatches in both directions.
+only_in_dockerfile="$(comm -23 "${tmpdir}/dockerfile" "${tmpdir}/lockfile")"
+only_in_lockfile="$(comm -13 "${tmpdir}/dockerfile" "${tmpdir}/lockfile")"
+
+errors=0
+
+if [[ -n "${only_in_dockerfile}" ]]; then
+  echo "ARGs in Dockerfile missing from versions.lock:" >&2
+  echo "  ${only_in_dockerfile//$'\n'/$'\n'  }" >&2
+  errors=1
+fi
+
+if [[ -n "${only_in_lockfile}" ]]; then
+  echo "Keys in versions.lock missing from Dockerfile:" >&2
+  echo "  ${only_in_lockfile//$'\n'/$'\n'  }" >&2
+  errors=1
+fi
+
+[[ "${errors}" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

A typo in `versions.lock` silently passes an empty string to a Dockerfile ARG, causing cryptic checksum failures at build time. This PR adds a pre-build validation step that compares lockfile keys against Dockerfile ARG declarations and fails early with a clear mismatch report.

## Related Issues

Fixes #22

## Changes

- Add `scripts/lib/validate-lockfile.sh` that extracts bare ARGs from the Dockerfile and keys from `versions.lock`, then reports mismatches in both directions
- Add `lint-lockfile` Make target wired into `make lint` as the first dependency