### PR TITLE
Fix misleading comment in package-release.sh

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -77,7 +77,8 @@ fi
 echo "Staged files:"
 ls -1 "${STAGING}"
 
-# Create per-platform archives (identical content, separate SHA256s)
+# Create per-platform archives for homebrew-tap per-platform manifests.
+# Content is identical (bash scripts are platform-agnostic).
 for platform in "${PLATFORMS[@]}"; do
   archive="ci-tools_${VERSION}_${platform}.tar.gz"
   tar -czf "${RELEASE}/${archive}" -C "${STAGING}" .


### PR DESCRIPTION
## Summary

The comment said "identical content, separate SHA256s" but all four tarball checksums are actually identical since the tools are platform-agnostic bash scripts and `tar -czf` is deterministic. Updated to clarify the archives exist for homebrew-tap per-platform manifests.

## Related Issues

Refs #38