### PR TITLE
Fix make man on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ lint-man:
 
 # Preview man pages
 man:
-	@man -l docs/man/man1/*.1
+	@mandoc -a docs/man/man1/*.1
 
 # Build and test deb package locally
 test-package:


### PR DESCRIPTION
## Summary

`make man` fails on macOS because `man -l` is a Linux-only flag. Switching to `mandoc -a` works on both macOS and Linux.

## Related Issues

Fixes #44

## Changes

- Replace `man -l` with `mandoc -a` in the Makefile `man` target