### PR TITLE
Invoke scripts via shebang instead of explicit `bash`

### DIFF
--- a/.github/actions/build-deb/action.yml
+++ b/.github/actions/build-deb/action.yml
@@ -41,4 +41,4 @@ runs:
       shell: bash
       env:
         VERSION: ${{ inputs.version }}
-      run: bash scripts/package-deb.sh "${VERSION}"
+      run: ./scripts/package-deb.sh "${VERSION}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       # Version is a placeholder — CI exercises the packaging pipeline,
       # not a real release. The publish workflow uses the git tag.
       - name: Stage release artifacts
-        run: bash scripts/package-release.sh 0.0.0
+        run: ./scripts/package-release.sh 0.0.0
 
       - name: Build .deb package
         uses: ./.github/actions/build-deb
@@ -89,4 +89,4 @@ jobs:
           path: deb
 
       - name: Verify installation
-        run: bash ./scripts/verify-deb-install.sh ./deb/ci-tools_*_${{ matrix.arch }}.deb
+        run: ./scripts/verify-deb-install.sh ./deb/ci-tools_*_${{ matrix.arch }}.deb

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Build release archives
         env:
           VERSION: ${{ steps.tag-version.outputs.version }}
-        run: bash scripts/package-release.sh "${VERSION}"
+        run: ./scripts/package-release.sh "${VERSION}"
 
       - name: Build deb packages
         uses: ./.github/actions/build-deb
@@ -101,7 +101,7 @@ jobs:
           version: ${{ steps.tag-version.outputs.version }}
 
       - name: Generate checksums
-        run: bash scripts/generate-checksums.sh
+        run: ./scripts/generate-checksums.sh
 
       - name: Upload package artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ verify:
 	@docker run --rm \
 		-v $(CURDIR)/scripts:/scripts \
 		-v $(CURDIR)/images/$(IMAGE)/versions.lock:/versions.lock:ro \
-		$(IMAGE_TAG) bash /scripts/$(IMAGE)/verify.sh
+		$(IMAGE_TAG) /scripts/$(IMAGE)/verify.sh
 
 # Run all linters
 lint: lint-lockfile lint-docker lint-sh lint-sh-fmt lint-actions lint-md lint-man
@@ -92,7 +92,7 @@ man:
 
 # Build and test deb package locally
 test-package:
-	@bash tests/deb/test-all.sh
+	@./tests/deb/test-all.sh
 
 # Remove local image
 clean:

--- a/tests/deb/test-all.sh
+++ b/tests/deb/test-all.sh
@@ -53,11 +53,11 @@ echo "Host architecture: ${HOST_ARCH} (${HOST_DEB_ARCH})"
 # Build all packages
 echo ""
 echo "Staging release artifacts..."
-bash scripts/package-release.sh "${VERSION}"
+./scripts/package-release.sh "${VERSION}"
 
 echo ""
 echo "Building deb packages..."
-bash scripts/package-deb.sh "${VERSION}"
+./scripts/package-deb.sh "${VERSION}"
 
 # Test packages
 FAILED=0

--- a/tests/deb/test-package.sh
+++ b/tests/deb/test-package.sh
@@ -55,4 +55,4 @@ docker run --rm \
   -v "${DEB_DIR}:/deb:ro" \
   -v "${REPO_ROOT}/scripts:/scripts:ro" \
   "${IMAGE}" \
-  bash /scripts/verify-deb-install.sh "/deb/${DEB_FILENAME}"
+  /scripts/verify-deb-install.sh "/deb/${DEB_FILENAME}"


### PR DESCRIPTION
## Summary

All invoked scripts already have `#!/usr/bin/env bash` shebangs, making explicit `bash script.sh` calls redundant. This replaces them with `./script.sh` (or absolute paths for container contexts) so the shebang is the single source of truth for the interpreter.

Fixes #48

## Changes

- Replace 10 `bash script.sh` invocations with direct `./script.sh` or `/script.sh` across Makefile, CI/publish workflows, the build-deb action, and test scripts