### PR TITLE
Add Docker, Homebrew, and Apt install badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # devops
 
+[![Docker](https://img.shields.io/badge/install-docker-blue)](https://github.com/knight-owl-dev/devops/pkgs/container/ci-tools)
+[![Homebrew](https://img.shields.io/badge/install-homebrew-brightgreen)](https://brew.sh)
+[![Apt](https://img.shields.io/badge/install-apt-blue)](https://apt.knight-owl.dev)
+
 Shared CI/CD infrastructure for Knight Owl repositories.
 
 ## Why This Repo Exists


### PR DESCRIPTION
## Summary

Adds install badges to the top of the README so visitors can quickly see that ci-tools is available via Docker, Homebrew, and Apt.

Fixes #50

## Changes

- Add Docker, Homebrew, and Apt shield.io badges below the heading in `README.md`