### PR TITLE
Use Bash array for TEST_IMAGES in test-all.sh

### DIFF
--- a/tests/deb/test-all.sh
+++ b/tests/deb/test-all.sh
@@ -45,7 +45,7 @@ esac
 
 VERSION="0.0.0"
 ARCHS=(amd64 arm64)
-TEST_IMAGES="debian:bookworm-slim ubuntu:24.04"
+TEST_IMAGES=(debian:bookworm-slim ubuntu:24.04)
 
 echo "Building and testing ci-tools v${VERSION}"
 echo "Host architecture: ${HOST_ARCH} (${HOST_DEB_ARCH})"
@@ -78,7 +78,7 @@ for arch in "${ARCHS[@]}"; do
     continue
   fi
 
-  for image in ${TEST_IMAGES}; do
+  for image in "${TEST_IMAGES[@]}"; do
     echo ""
     echo "Testing ${deb_file} on ${image}..."
 


### PR DESCRIPTION
## Summary

Replace the word-split string `TEST_IMAGES` with a proper Bash array so iteration does not rely on implicit word splitting, consistent with the project's strict shellcheck configuration and the pattern already used by `ARCHS` in the same script.

Fixes #52

## Changes

- Convert `TEST_IMAGES` from a plain string to an array declaration
- Update the `for` loop to iterate with `"${TEST_IMAGES[@]}"`