### PR TITLE
Add GNU parallel to ci-tools image

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ CI pipelines. Published to GHCR at `ghcr.io/knight-owl-dev/ci-tools`.
 | [hadolint](https://github.com/hadolint/hadolint) | Dockerfile linting |
 | [luacheck](https://github.com/lunarmodules/luacheck) | Lua script linting |
 | [make](https://www.gnu.org/software/make/) | Build automation |
+| [parallel](https://www.gnu.org/software/parallel/) | Parallel execution backend for bats --jobs |
 | [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) | Markdown linting |
 | [rsync](https://rsync.samba.org) | File synchronization for build assembly |
 | [shellcheck](https://github.com/koalaman/shellcheck) | Shell script linting |
@@ -116,6 +117,7 @@ respective communities:
 - [stylelint](https://github.com/stylelint/stylelint) by stylelint contributors (MIT)
 - [ChkTeX](https://www.nongnu.org/chktex/) by ChkTeX contributors (GPLv2+)
 - [bats-core](https://github.com/bats-core/bats-core) by bats-core contributors (MIT)
+- [GNU Parallel](https://www.gnu.org/software/parallel/) by Ole Tange (GPLv3+)
 
 ## License
 

--- a/images/ci-tools/Dockerfile
+++ b/images/ci-tools/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
     shellcheck \
     chktex \
     mandoc \
+    parallel \
     jq \
     make \
     curl \
@@ -21,6 +22,9 @@ RUN apt-get update \
     git \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+# Silence GNU parallel's citation notice in CI logs
+RUN mkdir -p /root/.parallel && touch /root/.parallel/will-cite
 
 # ---------- platform ----------
 ARG TARGETARCH

--- a/scripts/ci-tools/verify.sh
+++ b/scripts/ci-tools/verify.sh
@@ -47,4 +47,5 @@ check "bats-file" "" ls /usr/lib/bats/bats-file/load.bash
 check "rsync" "" rsync --version
 check "git" "" git --version
 check "make" "" make --version
+check "parallel" "" parallel --version
 verify_exit


### PR DESCRIPTION
## Summary

Bats-core's `--jobs N` flag requires GNU `parallel` as a runtime dependency. Without it, parallel test execution fails with `parallel: command not found`. This adds parallel to the ci-tools image so downstream projects (keystone) can drop their custom bats Dockerfile and run `make test-scripts local=1` directly in CI.

## Related Issues

Refs #59

## Changes

- Install `parallel` via apt in the ci-tools Dockerfile
- Pre-create `/root/.parallel/will-cite` to silence the citation notice in CI logs
- Add verification check for parallel in `verify.sh`
- Document parallel in the README tools table and acknowledgments