### PR TITLE
Add scheduled CVE monitoring for published images

### DIFF
--- a/.github/workflows/cve-monitor.yml
+++ b/.github/workflows/cve-monitor.yml
@@ -1,0 +1,76 @@
+name: CVE Monitor
+
+on:
+  schedule:
+    # Monday and Thursday at 08:00 UTC
+    - cron: '0 8 * * 1,4'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan ${{ matrix.image }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+      issues: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [ci-tools] # extend when adding images
+
+    steps:
+      - name: Checkout
+        # Sparse checkout: per-image .trivyignore and the issue body template.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: |
+            images/${{ matrix.image }}/.trivyignore
+            docs/cve-monitor-issue.md
+          sparse-checkout-cone-mode: false
+
+      - name: Scan published image for vulnerabilities
+        # Same policy as publish: CRITICAL+HIGH, ignore-unfixed
+        uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # 0.34.0
+        with:
+          image-ref: 'ghcr.io/knight-owl-dev/${{ matrix.image }}:latest'
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          trivyignores: images/${{ matrix.image }}/.trivyignore
+          format: 'table'
+          output: 'trivy-results.txt'
+
+      - name: Open issue on findings
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE: ${{ matrix.image }}
+        run: |
+          open_issues=$(
+            gh issue list \
+              --label cve-monitor \
+              --search "in:title ${IMAGE}" \
+              --state open \
+              --json number \
+              --jq 'length'
+          )
+          if [ "${open_issues}" -gt 0 ]; then
+            echo "Open cve-monitor issue for ${IMAGE} already exists — skipping."
+            exit 0
+          fi
+
+          sed -e "s/\$IMAGE/${IMAGE}/g" -e '/<!-- TRIVY_RESULTS -->/{
+            r trivy-results.txt
+            d
+          }' docs/cve-monitor-issue.md > /tmp/issue-body.md
+
+          gh issue create \
+            --title "CVE Monitor: fixable vulnerabilities in ${IMAGE}" \
+            --body-file /tmp/issue-body.md \
+            --label cve-monitor --label security

--- a/docs/cve-monitor-issue.md
+++ b/docs/cve-monitor-issue.md
@@ -1,0 +1,21 @@
+<!-- markdownlint-disable MD041 — no h1 needed; GitHub injects the issue title -->
+
+## CVE Monitor Alert
+
+The scheduled Trivy scan found fixable CRITICAL or HIGH vulnerabilities
+in the published image `ghcr.io/knight-owl-dev/$IMAGE:latest`.
+
+### Scan Results
+
+```text
+<!-- TRIVY_RESULTS -->
+```
+
+### Next Steps
+
+1. Review the findings above
+2. Update the base image or affected packages in `images/$IMAGE/Dockerfile`
+3. Cut a new release — the publish workflow re-scans before publishing
+
+See [docs/supply-chain-security.md](supply-chain-security.md)
+for scanning policy details.

--- a/docs/how-to/add-image.md
+++ b/docs/how-to/add-image.md
@@ -116,7 +116,19 @@ make sync IMAGE=<name>
 All image operations (`sync`, `resolve`, `build`, `verify`, `clean`) work
 automatically via the `IMAGE` variable — no Makefile changes needed.
 
-### 8. Add Makefile lint targets (if applicable)
+### 8. Add the image to workflow matrices
+
+Both `publish.yml` and `cve-monitor.yml` use a matrix strategy to iterate over
+images. Add `<name>` to the `matrix.image` array in **both** workflows so they
+stay in sync:
+
+```yaml
+# .github/workflows/publish.yml and .github/workflows/cve-monitor.yml
+matrix:
+  image: [ci-tools, <name>]
+```
+
+### 9. Add Makefile lint targets (if applicable)
 
 If the new tool should run as part of `make lint`, add it to the Makefile. For
 repo-local scripts that are also installed in the container image, prefer the
@@ -131,7 +143,7 @@ MY_TOOL := $(shell command -v my-tool 2>/dev/null || echo images/<name>/bin/my-t
 This keeps bare-metal development working while ensuring CI runs the same
 version that shipped in the image.
 
-### 9. Set up distributable packaging (local tools only)
+### 10. Set up distributable packaging (local tools only)
 
 If the local tool should be installable outside Docker (via Homebrew or apt),
 add it to the packaging pipeline:

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -131,6 +131,23 @@ Run the same scan locally:
 make scan
 ```
 
+### Scheduled CVE Monitoring
+
+Between releases, new CVEs can be disclosed against packages already in the
+published images. The `cve-monitor.yml` workflow closes this gap by scanning
+each published image on a schedule (Monday and Thursday at 08:00 UTC) and can
+also be triggered manually from the Actions tab.
+
+The scan uses the same Trivy policy as the publish workflow: CRITICAL and HIGH
+severity, `ignore-unfixed: true`, with the per-image `.trivyignore`. A clean
+scan produces a silent green run. If fixable vulnerabilities are found, the
+workflow opens a GitHub issue labeled `cve-monitor` and `security` with the
+full scan results.
+
+To avoid duplicate noise, the workflow checks for an existing open issue for
+that image before creating a new one. Once the vulnerability is remediated and
+a new release is cut, close the issue manually.
+
 ### SBOM Generation
 
 The multi-platform push step generates a Software Bill of Materials (SBOM)


### PR DESCRIPTION
## Summary

Proactively detect new CVEs disclosed against packages in published Docker images between releases. The publish workflow and `make scan` only cover release time and local ad-hoc runs — this adds a scheduled scan of the already-published GHCR images that opens a GitHub issue when fixable vulnerabilities are found.

## Related Issues

Fixes #63

## Changes

- Add `cve-monitor.yml` workflow with matrix strategy, twice-weekly schedule (Mon/Thu 08:00 UTC), and manual dispatch
- Scan `ghcr.io/knight-owl-dev/<image>:latest` with the same Trivy policy as publish (CRITICAL+HIGH, ignore-unfixed, per-image `.trivyignore`)
- Per-image issue deduplication via title search and `cve-monitor` label filtering
- Add `docs/cve-monitor-issue.md` as a lintable issue body template with `$IMAGE` placeholder
- Document scheduled monitoring in `docs/supply-chain-security.md`
- Add workflow matrix step to `docs/how-to/add-image.md` so future images are added to both `publish.yml` and `cve-monitor.yml`