### PR TITLE
Harden CVE monitor against race conditions and false positives

### DIFF
--- a/.github/workflows/cve-monitor.yml
+++ b/.github/workflows/cve-monitor.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: cve-monitor
+
 jobs:
   scan:
     name: Scan ${{ matrix.image }}
@@ -35,6 +38,8 @@ jobs:
           sparse-checkout-cone-mode: false
 
       - name: Scan published image for vulnerabilities
+        id: trivy
+        continue-on-error: true
         # Same policy as publish: CRITICAL+HIGH, ignore-unfixed
         uses: aquasecurity/trivy-action@c1824fd6edce30d7ab345a9989de00bbd46ef284 # 0.34.0
         with:
@@ -47,7 +52,7 @@ jobs:
           output: 'trivy-results.txt'
 
       - name: Open issue on findings
-        if: failure()
+        if: steps.trivy.outcome == 'failure'
         env:
           GH_TOKEN: ${{ github.token }}
           IMAGE: ${{ matrix.image }}
@@ -57,6 +62,7 @@ jobs:
               --label cve-monitor \
               --search "in:title ${IMAGE}" \
               --state open \
+              --limit 1 \
               --json number \
               --jq 'length'
           )

--- a/docs/cve-monitor-issue.md
+++ b/docs/cve-monitor-issue.md
@@ -17,5 +17,5 @@ in the published image `ghcr.io/knight-owl-dev/$IMAGE:latest`.
 2. Update the base image or affected packages in `images/$IMAGE/Dockerfile`
 3. Cut a new release — the publish workflow re-scans before publishing
 
-See [docs/supply-chain-security.md](supply-chain-security.md)
+See [docs/supply-chain-security.md](docs/supply-chain-security.md)
 for scanning policy details.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 — no h1 needed; GitHub injects this into the PR body -->

## Summary

The initial CVE monitor workflow (#64) had several correctness issues identified from the upstream keystone implementation (knight-owl-dev/keystone#104): overlapping runs could create duplicate issues, non-Trivy failures (auth errors, network timeouts) could trigger false-positive issue creation, the issue existence check fetched unnecessary data, and the issue body template contained a broken relative link. This PR fixes all four issues.

## Related Issues

Refs #63

## Changes

- Add workflow-level concurrency group to prevent duplicate runs from overlapping schedule and manual triggers
- Scope issue creation to Trivy scan failures only by checking step outcome instead of using the broad `failure()` condition
- Add `--limit 1` to `gh issue list` since only existence of an open issue matters
- Fix broken relative link to `supply-chain-security.md` in the issue body template