### PR TITLE
Add GPG to ci-tools image

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ CI pipelines. Published to GHCR at `ghcr.io/knight-owl-dev/ci-tools`.
 | [biome](https://github.com/biomejs/biome) | JavaScript/TypeScript linting |
 | [chktex](https://www.nongnu.org/chktex/) | LaTeX document linting |
 | [git](https://git-scm.com) | Version control (build-time cloning and runtime use) |
+| [gpg](https://gnupg.org) | GPG signature verification |
 | [hadolint](https://github.com/hadolint/hadolint) | Dockerfile linting |
 | [luacheck](https://github.com/lunarmodules/luacheck) | Lua script linting |
 | [make](https://www.gnu.org/software/make/) | Build automation |

--- a/images/ci-tools/Dockerfile
+++ b/images/ci-tools/Dockerfile
@@ -20,8 +20,13 @@ RUN apt-get update \
     gcc \
     rsync \
     git \
+    gnupg \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+# ---------- gpg ----------
+ENV GNUPGHOME=/tmp/gnupg
+RUN mkdir -m 700 "${GNUPGHOME}"
 
 # Silence GNU parallel's citation notice in CI logs
 RUN mkdir -p /root/.parallel && touch /root/.parallel/will-cite

--- a/scripts/ci-tools/verify.sh
+++ b/scripts/ci-tools/verify.sh
@@ -46,6 +46,7 @@ check "bats-assert" "" ls /usr/lib/bats/bats-assert/load.bash
 check "bats-file" "" ls /usr/lib/bats/bats-file/load.bash
 check "rsync" "" rsync --version
 check "git" "" git --version
+check "gpg" "" gpg --version
 check "make" "" make --version
 check "parallel" "" parallel --version
 verify_exit


### PR DESCRIPTION
## Summary

CI workflows need `gpg` for signature verification, but the ci-tools image only has the low-level `libgpg-error0` library as a transitive dependency — the `gpg` binary itself is not present. This adds `gnupg` as an unpinned apt package so pipelines can verify GPG signatures and manage keyrings without installing packages at workflow time.

## Related Issues

Fixes #66

## Changes

- Add `gnupg` to the apt install list in the ci-tools Dockerfile
- Set `GNUPGHOME=/tmp/gnupg` so gpg operations use a throwaway directory instead of polluting `~/.gnupg`
- Add a `gpg` presence check to the verification script
- Add `gpg` to the tools table in the README