### PR TITLE
Add `en_US.UTF-8` locale to ci-tools image

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ CI pipelines. Published to GHCR at `ghcr.io/knight-owl-dev/ci-tools`.
 Pinned versions and checksums are tracked in
 [`images/ci-tools/versions.lock`](images/ci-tools/versions.lock).
 
+### Locale
+
+The image defaults to `LC_ALL=C` for deterministic sorting and output. The
+`en_US.UTF-8` locale is installed so tests can `export LC_ALL=en_US.UTF-8` to
+verify locale-independent behavior without the setting silently falling back
+to C.
+
 ### Usage
 
 Reference the image in a GitHub Actions workflow:

--- a/images/ci-tools/Dockerfile
+++ b/images/ci-tools/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
     mandoc \
     parallel \
     jq \
+    locales \
     make \
     curl \
     ca-certificates \
@@ -23,6 +24,12 @@ RUN apt-get update \
     gnupg \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
+# ---------- locale ----------
+# Generate en_US.UTF-8 so tests can verify locale-independent behavior.
+# The locale is available but not active — LC_ALL=C is pinned below.
+RUN sed -i 's/^# *en_US.UTF-8/en_US.UTF-8/' /etc/locale.gen \
+  && locale-gen
 
 # ---------- gpg ----------
 ENV GNUPGHOME=/tmp/gnupg
@@ -135,6 +142,8 @@ COPY --chmod=755 bin/validate-action-pins /usr/local/bin/validate-action-pins
 # Images run as root because they target CI runners (GitHub Actions) where the
 # workspace is owned by root. Consumers would need to escalate to root anyway,
 # so a non-root USER directive only adds friction without meaningful isolation.
+
+ENV LC_ALL=C
 
 # ---------- metadata ----------
 ARG IMAGE_VERSION=local

--- a/scripts/ci-tools/verify.sh
+++ b/scripts/ci-tools/verify.sh
@@ -52,4 +52,6 @@ check "git" "" git --version
 check "gpg" "" gpg --version
 check "make" "" make --version
 check "parallel" "" parallel --version
+check "locale-en-us" "" bash -c "locale -a | grep -q en_US.utf8"
+check "lc-all-default" "C" printenv LC_ALL
 verify_exit


### PR DESCRIPTION
## Summary

Make `en_US.UTF-8` available in the ci-tools container so BATS tests can verify locale-independent behavior without `export LC_ALL=en_US.UTF-8` silently falling back to C. Pin `LC_ALL=C` as the explicit container default to match GitHub Actions behavior.

## Related Issues

Fixes #76

## Changes

- Install `locales` package and generate `en_US.UTF-8` (available but not active)
- Pin `ENV LC_ALL=C` in the Dockerfile runtime section
- Add `locale-en-us` and `lc-all-default` checks to `verify.sh`
- Document locale configuration in README

## Further Comments

`make lint`, `make build`, and `make verify` all pass locally. The `locales` package is an apt dependency (intentionally unpinned per existing hadolint ignore) — no lockfile changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)