### PR TITLE
Link CVE Monitor issues to workflow run instead of inlining results

### DIFF
--- a/.github/workflows/cve-monitor.yml
+++ b/.github/workflows/cve-monitor.yml
@@ -49,7 +49,6 @@ jobs:
           ignore-unfixed: true
           trivyignores: images/${{ matrix.image }}/.trivyignore
           format: 'table'
-          output: 'trivy-results.txt'
 
       - name: Open issue on findings
         if: steps.trivy.outcome == 'failure'
@@ -71,10 +70,9 @@ jobs:
             exit 0
           fi
 
-          sed -e "s/\$IMAGE/${IMAGE}/g" -e '/<!-- TRIVY_RESULTS -->/{
-            r trivy-results.txt
-            d
-          }' docs/cve-monitor-issue.md > /tmp/issue-body.md
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          sed -e "s|\$IMAGE|${IMAGE}|g" -e "s|\$RUN_URL|${run_url}|g" \
+            docs/cve-monitor-issue.md > /tmp/issue-body.md
 
           gh issue create \
             --title "CVE Monitor: fixable vulnerabilities in ${IMAGE}" \

--- a/docs/cve-monitor-issue.md
+++ b/docs/cve-monitor-issue.md
@@ -5,17 +5,12 @@
 The scheduled Trivy scan found fixable CRITICAL or HIGH vulnerabilities
 in the published image `ghcr.io/knight-owl-dev/$IMAGE:latest`.
 
-### Scan Results
-
-```text
-<!-- TRIVY_RESULTS -->
-```
-
 ### Next Steps
 
-1. Review the findings above
-2. Update the base image or affected packages in `images/$IMAGE/Dockerfile`
-3. Cut a new release — the publish workflow re-scans before publishing
+1. Review the [workflow run]($RUN_URL) that triggered this alert
+2. Build and scan the image locally to investigate findings
+3. Update the base image or affected packages in `images/$IMAGE/Dockerfile`
+4. Cut a new release — the publish workflow re-scans before publishing
 
 See [docs/supply-chain-security.md](docs/supply-chain-security.md)
 for scanning policy details.


### PR DESCRIPTION
## Summary

- Replace inline Trivy table output in CVE Monitor issues with a link to the workflow run
- Drop `output: trivy-results.txt` so scan results print directly to the log
- Update issue template to reflect the "scan locally" workflow

Fixes #84

## Test plan

- [ ] Trigger CVE Monitor via `workflow_dispatch` and verify the created issue links to the run
- [ ] Confirm the Trivy table output appears in the workflow log

🤖 Generated with [Claude Code](https://claude.com/claude-code)