### PR TITLE
Migrate create-github-app-token from app-id to client-id

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -186,7 +186,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: knight-owl-dev
           repositories: |


### PR DESCRIPTION
## Summary

Silences the deprecation warning emitted by `actions/create-github-app-token` in the publish workflow. The `app-id` input was deprecated in v3.1.0 (2026-04-11) in favour of `client-id`, and the action is currently pinned at v3.1.1 so the
warning is emitted on every release run. Moving to `client-id` also uses the GitHub App's public Client ID via a repo variable rather than the numeric App ID from a secret, matching upstream's recommended usage.

## Related Issues

Fixes #120

## Changes

- Replace `app-id: ${{ secrets.APP_ID }}` with `client-id: ${{ vars.APP_CLIENT_ID }}` at `.github/workflows/publish.yml:189`.

## Further Comments

- The `APP_CLIENT_ID` repo variable has been populated out-of-band with the GitHub App's Client ID.
- Follow-up housekeeping (not in this PR): delete the now-unused `APP_ID` repo secret once this lands and the next release run is green.
- Sibling migration issues filed across the org: `knight-owl-dev/keystone#352`, `knight-owl-dev/keystone-cli#184`, `knight-owl-dev/homebrew-tap#54`, `knight-owl-dev/apt#59`.