### PR TITLE
Set the bot git identity before the release commit

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -92,6 +92,17 @@ for name in "${changed[@]}"; do
   "${SCRIPT_DIR}/set-image-version.sh" "${name}" "${VERSION}"
 done
 
+# In CI, set the bot identity and token remote BEFORE committing/pushing: the
+# commit needs an author, and the push + PR must run as the App (whose token
+# triggers PR CI). Locally, the caller's own git identity, remote, and gh auth
+# are used.
+if [[ -n "${GH_TOKEN:-}" && -n "${GITHUB_REPOSITORY:-}" ]]; then
+  git config user.name "github-actions[bot]"
+  git config user.email "github-actions[bot]@users.noreply.github.com"
+  git remote set-url origin \
+    "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+fi
+
 # Open the release PR. The branch name encodes the version; tag-release.yml
 # parses it and promotes the tag on merge.
 BRANCH="release/v${VERSION}"
@@ -101,15 +112,6 @@ for name in "${changed[@]}"; do
   git add "images/${name}/version"
 done
 git commit -m "Release v${VERSION}"
-
-# In CI, push and create the PR as the App so the PR triggers CI; locally, use
-# the caller's existing git remote and gh auth.
-if [[ -n "${GH_TOKEN:-}" && -n "${GITHUB_REPOSITORY:-}" ]]; then
-  git config user.name "github-actions[bot]"
-  git config user.email "github-actions[bot]@users.noreply.github.com"
-  git remote set-url origin \
-    "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-fi
 
 git push -u origin "${BRANCH}"
 


### PR DESCRIPTION
## Summary

The first real `make release` run (via the Release workflow) failed: detection and stamping worked (ci-tools → 1.2.6, branch created), but `git commit` failed with **"Author identity unknown."** `release.sh` set the `github-actions[bot]` git identity inside the CI auth block, which ran *after* the commit, so a fresh runner had no author configured at commit time. Nothing was pushed (the commit failed first), so no stray branch or PR resulted.

## Changes

- Move the bot identity + token-remote setup ahead of the branch creation and commit in `scripts/release.sh`, so the commit has an author and the push/PR still run as the App.

## Further Comments

- This is the git/gh-orchestration path that's deliberately not bats-covered (matching the apt/homebrew `create-update-pr.sh` precedent); the first real run is what exercised it.
- `allow_auto_merge` is already enabled on `devops`, so the `AUTOMERGE=1` path (which the kicked-off run used) won't hit a second wall once this lands. Re-run the **Release** workflow after merge.