### PR TITLE
Scan changed images before cutting a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,11 @@ jobs:
           fetch-depth: 0 # full history + tags for the per-image diff base
           persist-credentials: false
 
+      - name: Set up Docker Buildx
+        # make release scans each changed image (make scan -> builds it), so the
+        # runner needs Buildx available.
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
       - name: Generate GitHub App token
         id: app-token
         # Needs contents:write (push the release branch) + pull-requests:write

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,11 +10,12 @@ set -euo pipefail
 # Usage:
 #   ./scripts/release.sh <version>
 #
-# Environment (CI only):
-#   GH_TOKEN           GitHub App token used for push + PR creation, so the
+# Environment:
+#   GH_TOKEN           (CI) GitHub App token used for push + PR creation, so the
 #                      release PR triggers CI. Omit locally to use your own
 #                      git/gh auth.
-#   GITHUB_REPOSITORY  owner/repo, used to set the token push remote in CI.
+#   GITHUB_REPOSITORY  (CI) owner/repo, used to set the token push remote.
+#   SKIP_SCAN          Set to bypass the pre-release CVE scan of changed images.
 #
 # Exit codes:
 #   0 - Release PR opened
@@ -86,6 +87,17 @@ fi
 
 echo "Images to release at v${VERSION}:"
 printf '  %s\n' "${changed[@]}"
+
+# Scan the images about to be released so a fixable CVE fails here — before the
+# release PR and the promoted tag — rather than at publish (which would leave an
+# orphan tag and an ahead stamp). Same trivy policy / .trivyignore as publish.
+# Set SKIP_SCAN=1 to bypass (e.g. re-running after a known-accepted state).
+if [[ -z "${SKIP_SCAN:-}" ]]; then
+  for name in "${changed[@]}"; do
+    echo "Scanning ${name} for vulnerabilities..."
+    make scan IMAGE="${name}"
+  done
+fi
 
 # Stamp each changed image to the release version.
 for name in "${changed[@]}"; do


### PR DESCRIPTION
## Summary

The first real release failed at `publish`'s Trivy scan *after* the release PR had merged and tag `v1.2.6` was promoted — leaving an orphan tag and a stamp ahead of what's published. The scan only ran in `publish`, too late to prevent that. This moves the gate forward: `make release` now scans each image it's about to release, before opening the PR, so a fixable CVE aborts up front (no PR, no tag, no ahead stamp).

## Changes

- `scripts/release.sh`: after change-detection and before stamping/opening the PR, run `make scan IMAGE=<name>` for each changed image (same trivy severity / `.trivyignore` as publish, so a clean local scan == a clean publish). `SKIP_SCAN=1` bypasses (e.g. re-running after a known-accepted state).
- `release.yml`: add a Docker Buildx setup step so the build behind `make scan` runs on the runner.

## Further Comments

- This gates both the **local** `make release` (automating "scan before releasing") and the **Release workflow** — the orchestration lives in `release.sh` because the changed set is computed there; `make scan` stays the single per-image primitive.
- Cost: each changed image is built once at release-prep to scan it — the same build `publish` does, just earlier and fail-fast.
- The CI path is exercised on the next real release (the Release workflow is `workflow_dispatch`, so this PR's CI doesn't run it).
- Does **not** remediate the current ci-tools CVEs (base-image kernel headers + Go stdlib) — that's separate image maintenance, still needed before a release can go green.