### PR TITLE
Bump ci-tools base image and suppress residual Go stdlib CVEs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ scan: build
 	@docker run --rm $(DOCKER_TTY) \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(CURDIR)/images/$(IMAGE)/.trivyignore:/.trivyignore:ro \
-		aquasec/trivy:0.70.0 image \
+		aquasec/trivy:0.71.0 image \
 		--severity CRITICAL,HIGH \
 		--ignore-unfixed \
 		--exit-code 1 \

--- a/images/ci-tools/.trivyignore
+++ b/images/ci-tools/.trivyignore
@@ -78,3 +78,35 @@ CVE-2026-39836
 # Remove this entry once all three ship builds on Go >= 1.25.10 or 1.26.3.
 # Tracking issue: #96
 CVE-2026-42499
+
+# net/url: incomplete fix for CVE-2026-27142 (URLs not parsed/escaped safely)
+# (fixed in Go 1.25.10 / 1.26.3)
+# Affects: actionlint v1.7.12 (Go 1.26.1), shfmt v3.13.1 (Go 1.26.1),
+#          yq v4.53.2 (Go 1.26.2)
+# Remove this entry once all three ship builds on Go >= 1.25.10 or 1.26.3.
+# Tracking issue: #96
+CVE-2026-39823
+
+# net/http/httputil: ReverseProxy forwards unsanitized query parameters
+# (fixed in Go 1.25.10 / 1.26.3)
+# Affects: actionlint v1.7.12 (Go 1.26.1), shfmt v3.13.1 (Go 1.26.1),
+#          yq v4.53.2 (Go 1.26.2)
+# Remove this entry once all three ship builds on Go >= 1.25.10 or 1.26.3.
+# Tracking issue: #96
+CVE-2026-39825
+
+# html/template: script-context escaping flaw for crafted template input
+# (fixed in Go 1.25.10 / 1.26.3)
+# Affects: actionlint v1.7.12 (Go 1.26.1), shfmt v3.13.1 (Go 1.26.1),
+#          yq v4.53.2 (Go 1.26.2)
+# Remove this entry once all three ship builds on Go >= 1.25.10 or 1.26.3.
+# Tracking issue: #96
+CVE-2026-39826
+
+# net/textproto: DoS decoding a maliciously-crafted MIME header
+# (fixed in Go 1.25.11 / 1.26.4)
+# Affects: actionlint v1.7.12 (Go 1.26.1), shfmt v3.13.1 (Go 1.26.1),
+#          yq v4.53.2 (Go 1.26.2)
+# Remove this entry once all three ship builds on Go >= 1.25.11 or 1.26.4.
+# Tracking issue: #96
+CVE-2026-42504

--- a/images/ci-tools/Dockerfile
+++ b/images/ci-tools/Dockerfile
@@ -1,5 +1,5 @@
 # ci-tools — shared linting image for Knight Owl CI pipelines
-FROM node:26-bookworm-slim@sha256:e89172f5e6154ba212269866bf3fbadbca8eb7901e10c0eccf08f2147bfae505
+FROM node:26-bookworm-slim@sha256:79723b41edbedf595f62e943a9f8b0ba9af5b1e61045c5f8f59c2c02c1212a16
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -95,7 +95,10 @@ printf '  %s\n' "${changed[@]}"
 if [[ -z "${SKIP_SCAN:-}" ]]; then
   for name in "${changed[@]}"; do
     echo "Scanning ${name} for vulnerabilities..."
-    make scan IMAGE="${name}"
+    if ! make scan IMAGE="${name}"; then
+      echo "ERROR: ${name} has unresolved CRITICAL/HIGH CVEs — fix them (see the scan output above) or re-run with SKIP_SCAN=1." >&2
+      exit 1
+    fi
   done
 fi
 


### PR DESCRIPTION
## Summary

The first `v1.2.6` publish failed its Trivy gate on fixable CRITICAL/HIGH CVEs in the ci-tools image. This remediates them so a release can go green: bump the Debian base to clear the kernel-header CVEs, and suppress the residual Go-stdlib CVEs (no upstream fix to pull yet) with justification. Also makes the new pre-release scan's failure explicit.

## Related Issues

Fixes #140

Refs #96 (extends the tracked Go-stdlib suppressions to cover the new CVEs)
Refs #142 (adds more flat-format entries the expiring-format migration would absorb)

## Changes

- **Base image** — bump `node:26-bookworm-slim` to the current manifest-list digest, clearing the `linux-libc-dev` (kernel headers) HIGH CVEs.
- **Go stdlib suppressions** — add CVE-2026-39823 / 39825 / 39826 / 42504 to `images/ci-tools/.trivyignore` with per-CVE justification. `actionlint`, `shfmt`, and `yq` are all already at their latest upstream release (no Go-patched build exists), and these CVEs (net/url, ReverseProxy, html/template, MIME-header decode) are unreachable in offline lint/format/yaml-query CLI use.
- **release.sh** — make the pre-release `make scan` failure explicit (clear abort message + `SKIP_SCAN` hint) instead of relying on `set -e`.

## Further Comments

- `make scan` is clean after these changes (verified locally); `make lint` and `make test-bats` pass.
- Unblocks the release: once merged, `images/ci-tools/` build context has changed, so `make release VERSION=1.2.7` will detect it, the pre-step scan passes, and publish goes green.
- Not addressed: #135 (the base still ships `libgnutls30 3.7.9-2+deb12u6`, below the `deb12u7` threshold, so the explicit install stays).