### PR TITLE
Drop the pre-release CVE scan from make release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,6 @@ jobs:
           fetch-depth: 0 # full history + tags for the per-image diff base
           persist-credentials: false
 
-      - name: Set up Docker Buildx
-        # make release scans each changed image (make scan -> builds it), so the
-        # runner needs Buildx available.
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
       - name: Generate GitHub App token
         id: app-token
         # Needs contents:write (push the release branch) + pull-requests:write

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -15,7 +15,6 @@ set -euo pipefail
 #                      release PR triggers CI. Omit locally to use your own
 #                      git/gh auth.
 #   GITHUB_REPOSITORY  (CI) owner/repo, used to set the token push remote.
-#   SKIP_SCAN          Set to bypass the pre-release CVE scan of changed images.
 #
 # Exit codes:
 #   0 - Release PR opened
@@ -87,20 +86,6 @@ fi
 
 echo "Images to release at v${VERSION}:"
 printf '  %s\n' "${changed[@]}"
-
-# Scan the images about to be released so a fixable CVE fails here — before the
-# release PR and the promoted tag — rather than at publish (which would leave an
-# orphan tag and an ahead stamp). Same trivy policy / .trivyignore as publish.
-# Set SKIP_SCAN=1 to bypass (e.g. re-running after a known-accepted state).
-if [[ -z "${SKIP_SCAN:-}" ]]; then
-  for name in "${changed[@]}"; do
-    echo "Scanning ${name} for vulnerabilities..."
-    if ! make scan IMAGE="${name}"; then
-      echo "ERROR: ${name} has unresolved CRITICAL/HIGH CVEs — fix them (see the scan output above) or re-run with SKIP_SCAN=1." >&2
-      exit 1
-    fi
-  done
-fi
 
 # Stamp each changed image to the release version.
 for name in "${changed[@]}"; do


### PR DESCRIPTION
## Summary

The pre-release scan (added in #152) built each changed image at release-prep to trivy-scan it before opening the release PR. Two problems surfaced on the first real run: `make build` is multi-platform, and a multi-arch build **can't `--load` into a stock CI runner's docker store**, so the Release workflow failed with `No such image: ci-tools:local`; and it **duplicated** the scan `publish` already runs (with matrix parallelism + registry cache).

Drop it and let `publish`'s Trivy scan be the single gate.

## Changes

- Remove the scan loop (and `SKIP_SCAN`) from `scripts/release.sh`.
- Remove the now-unneeded Docker Buildx step from `release.yml`.

The #153 CVE remediation (base bump, `.trivyignore`, trivy 0.71.0) is unaffected.

## Further Comments

- Recovery model is unchanged and already agreed: a CVE failing `publish` (after the tag is promoted) **burns that release tag** — fix the content and cut a new release; for transient/non-content publish failures, re-run the `publish` run on the existing tag.
- After this merges, `make release VERSION=1.2.7` cuts cleanly through CI: ci-tools' CVEs are already fixed on `main` (#153), so `publish`'s scan passes.