### PR TITLE
Make local deb packaging marker-discoverable; revise add-image docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,9 +127,13 @@ lint-man:
 man:
 	@mandoc -a docs/man/man1/*/*.1
 
-# Build and test deb package locally
+# Build and test deb packages locally. Discovers distributable images via their
+# marker (like CI); pass IMAGE=<name> to scope to one. The target-specific empty
+# default overrides the global IMAGE=ci-tools so a bare `make test-package`
+# tests the whole distributable set; a command-line IMAGE=... still wins.
+test-package: IMAGE :=
 test-package:
-	@./tests/deb/test-all.sh
+	@IMAGE='$(IMAGE)' ./tests/deb/test-all.sh
 
 # Run BATS tests. BATS_RUNNER defaults to running inside the ci-tools
 # container via `docker run`, so `make test-bats` works from a stock
@@ -173,7 +177,8 @@ help:
 	@echo "  make lint-sh-fmt-fix   Fix shell script formatting"
 	@echo "  make man               Preview man pages"
 	@echo "  make test-bats         Run BATS tests inside the ci-tools image"
-	@echo "  make test-package      Build and test deb package locally"
+	@echo "  make test-package      Build and test debs for all distributable images"
+	@echo "  make test-package IMAGE=foo  Scope deb build/test to one image"
 	@echo "  make help              Show this message"
 	@echo ""
 	@echo "  * Writes images/\$$(IMAGE)/versions.lock"

--- a/docs/how-to/add-image.md
+++ b/docs/how-to/add-image.md
@@ -12,17 +12,21 @@ images/<name>/
 ├── compose.yaml         # local builds only: wires versions.lock → build args
 ├── versions.lock        # tracked: canonical tool versions + checksums
 ├── version              # tracked: release stamp, set by `make release` (don't hand-edit)
-├── .trivyignore         # optional: CVE suppressions (see below)
-└── bin/                 # optional: repo-local scripts shipped in the image
+├── .trivyignore         # optional: CVE suppressions (see "Vulnerability scanning")
+├── bin/                 # optional: repo-local scripts shipped in the image
+├── distributable        # optional: marks the image for packaging (step 11)
+└── nfpm.yaml            # optional: deb spec — distributable only (step 11)
 
 scripts/<name>/
 ├── resolve.sh           # resolve versions + checksums → versions.lock
-└── verify.sh            # verify tools in the built image
+├── verify.sh            # verify tools in the built image
+├── package-release.sh   # optional: stage tools into archives — distributable only (step 11)
+└── verify-deb-install.sh # optional: verify an installed deb — distributable only (step 11)
 ```
 
-Distributable images (those that ship `.deb` / Homebrew packages) add a few
-more files — see
-[step 11](#11-set-up-distributable-packaging-local-tools-only).
+Optional rows marked **distributable only** apply to images that ship `.deb` /
+Homebrew packages; a man page under `docs/man/man1/<name>/` completes that set.
+See [step 11](#11-set-up-distributable-packaging-local-tools-only) for setup.
 
 ### How the pipeline finds your image
 

--- a/docs/how-to/add-image.md
+++ b/docs/how-to/add-image.md
@@ -8,18 +8,57 @@ Every image uses the same layout. Replace `<name>` with your image name:
 
 ```text
 images/<name>/
-├── Dockerfile
-├── compose.yaml         # local builds: wires versions.lock → build args
+├── Dockerfile           # the image build
+├── compose.yaml         # local builds only: wires versions.lock → build args
+├── versions.lock        # tracked: canonical tool versions + checksums
 ├── version              # tracked: release stamp, set by `make release` (don't hand-edit)
-└── versions.lock        # tracked: canonical tool versions + checksums
+├── .trivyignore         # optional: CVE suppressions (see below)
+└── bin/                 # optional: repo-local scripts shipped in the image
 
 scripts/<name>/
 ├── resolve.sh           # resolve versions + checksums → versions.lock
-└── verify.sh            # verify tools in built image
+└── verify.sh            # verify tools in the built image
 ```
 
 Distributable images (those that ship `.deb` / Homebrew packages) add a few
-more files — see [step 11](#11-set-up-distributable-packaging-local-tools-only).
+more files — see
+[step 11](#11-set-up-distributable-packaging-local-tools-only).
+
+### How the pipeline finds your image
+
+Nothing is registered in a central list — two signals drive everything, and
+both are auto-discovered:
+
+- **`images/<name>/version` == the release tag** puts the image in a release's
+  **build set**. `make release` stamps it to the new version when the build
+  context changed; `compute-build-matrix.sh` then has `publish.yml` build and
+  push exactly the stamped images. (`compose.yaml`, `version`, and
+  `distributable` are excluded from the change check — editing them alone
+  doesn't force a rebuild.)
+- **`images/<name>/distributable`** (a presence-only marker) is the opt-in for
+  *packaging*. It is the single signal behind all three package paths:
+  `publish.yml` builds/uploads/dispatches `.deb` + tarball assets,
+  `ci.yml` builds and tests debs on every PR, and `make test-package`
+  discovers the image locally — all via `distributable_images()` in
+  `scripts/lib/images.sh`. Its contents are never read.
+
+### Vulnerability scanning
+
+`publish.yml` (and the scheduled `cve-monitor.yml`) scan the built image with
+Trivy for fixed `CRITICAL`/`HIGH` CVEs. Add `images/<name>/.trivyignore` only
+when you need to suppress a specific CVE — each entry needs a justification
+comment (see `images/ci-tools/.trivyignore`). A new image with a clean scan
+needs no such file.
+
+> `cve-monitor.yml` uses a **static** matrix (it scans `:latest`, which has no
+> version stamp to discover). When you add an image, add its name there so the
+> published image is scanned on schedule:
+>
+> ```yaml
+> # .github/workflows/cve-monitor.yml
+> matrix:
+>   image: [ci-tools, <name>]
+> ```
 
 ## Steps
 
@@ -142,14 +181,8 @@ image stamped to the release version (`images/<name>/version == <tag>`) and
 `ci.yml` builds/tests debs for each image with a `distributable` marker — so no
 matrix edit is needed in either.
 
-`cve-monitor.yml` still uses a static matrix; add `<name>` to it so the
-published image is scanned on schedule:
-
-```yaml
-# .github/workflows/cve-monitor.yml
-matrix:
-  image: [ci-tools, <name>]
-```
+The one exception is `cve-monitor.yml`, whose static matrix you must extend —
+see [Vulnerability scanning](#vulnerability-scanning) above.
 
 ### 10. Add Makefile lint targets (if applicable)
 
@@ -169,22 +202,41 @@ version that shipped in the image.
 ### 11. Set up distributable packaging (local tools only)
 
 If the image's local tools should be installable outside Docker (via Homebrew
-or apt), make the image **distributable**:
+or apt), make the image **distributable**. Packaging is opt-in: it applies only
+to images that provide the contract below, and the `distributable` marker is the
+signal (see
+[How the pipeline finds your image](#how-the-pipeline-finds-your-image)).
 
-1. Add an empty `images/<name>/distributable` marker — its presence opts the
-   image into deb/brew packaging, downstream dispatch, and the CI deb
-   build/test jobs.
-2. Add `images/<name>/nfpm.yaml` describing the deb (package name, contents,
-   symlinks, man page, copyright).
-3. Add `scripts/<name>/package-release.sh` to stage the tools into platform
-   archives, and `scripts/<name>/verify-deb-install.sh` to verify an installed
-   deb (binary path, symlink, version output, man page).
-4. Add a man page in `docs/man/man1/<name>/<tool>.1` (mdoc(7) format).
+**What you add (per-image):**
 
-The `.github/actions/build-deb` composite action (parametrized by `image`)
-handles the Go/nfpm toolchain. CI auto-discovers every distributable image and
-runs `build-deb` + `test-deb` for each on every PR. Use `make test-package` to
-run the same verification locally via Docker.
+1. `images/<name>/distributable` — the opt-in marker. Only its presence is
+   checked, never its contents; add a one-line comment explaining what it does
+   (mirror `images/ci-tools/distributable`).
+2. `images/<name>/nfpm.yaml` — the deb spec (package name, contents, symlinks,
+   man page, copyright). The deb is named from its `name:` field.
+3. `scripts/<name>/package-release.sh <version>` — stages the tools into
+   `artifacts/staging/` and builds the per-platform `.tar.gz` archives.
+4. `scripts/<name>/verify-deb-install.sh <deb>` — asserts an installed deb is
+   correct (binary path, symlink, `--version`, man page).
+5. `docs/man/man1/<name>/<tool>.1` — a man page (mdoc(7) format).
+
+**What's already generic (no per-image code):** `scripts/package-deb.sh` builds
+the deb from your `nfpm.yaml`; the `.github/actions/build-deb` composite action
+(input `image`) wraps the Go/nfpm toolchain; `tests/deb/test-package.sh` runs
+your `verify-deb-install.sh` inside a container. These take the image name as an
+argument, so they work for any distributable image unchanged.
+
+**Verifying locally** — `make test-package` auto-discovers every distributable
+image (via the marker), builds its debs, and tests the host-arch deb in Debian
+and Ubuntu containers. Scope to one image while iterating:
+
+```bash
+make test-package                 # all distributable images
+make test-package IMAGE=<name>    # just yours
+```
+
+CI mirrors this: `ci.yml` runs `build-deb` + `test-deb` for each discovered
+distributable image on every PR.
 
 At release time the publish workflow packages each distributable image into
 platform archives (`.tar.gz`) and Debian packages (`.deb`), uploads them to the

--- a/scripts/lib/images.sh
+++ b/scripts/lib/images.sh
@@ -40,3 +40,19 @@ image_build_context_changed() {
 
   return 0 # diff => changed
 }
+
+# Echo the names of images carrying a `distributable` marker, one per line, in
+# directory order. The marker's presence is the only signal — its contents are
+# ignored. This is the single opt-in source for everything package-related: the
+# CI deb build/test jobs (via list-distributable-images.sh) and the local
+# aggregator (tests/deb/test-all.sh) both discover the set through here.
+#
+# Assumes the current working directory is the repo root.
+distributable_images() {
+  local marker name
+  for marker in images/*/distributable; do
+    [[ -f "${marker}" ]] || continue
+    name="$(basename "$(dirname "${marker}")")"
+    printf '%s\n' "${name}"
+  done
+}

--- a/scripts/list-distributable-images.sh
+++ b/scripts/list-distributable-images.sh
@@ -21,12 +21,17 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # shellcheck source=scripts/lib/json.sh
 source "${SCRIPT_DIR}/lib/json.sh"
+# shellcheck source=scripts/lib/images.sh
+source "${SCRIPT_DIR}/lib/images.sh"
 
+# Capture then split (a here-string of "" would yield one empty element, so
+# guard the empty case). Assigning the command substitution preserves its exit
+# status, unlike piping into mapfile.
+discovered="$(distributable_images)"
 images=()
-for marker in images/*/distributable; do
-  [[ -f "${marker}" ]] || continue
-  images+=("$(basename "$(dirname "${marker}")")")
-done
+if [[ -n "${discovered}" ]]; then
+  mapfile -t images <<< "${discovered}"
+fi
 
 if [[ ${#images[@]} -gt 0 ]]; then
   images_json="$(json_array "${images[@]}")"

--- a/tests/bats/scripts/lib/images.bats
+++ b/tests/bats/scripts/lib/images.bats
@@ -87,3 +87,39 @@ _commit() {
   run image_build_context_changed ci-tools v9.9.9
   assert_success
 }
+
+@test "distributable_images lists only marked images, in directory order" {
+  # The base repo seeds images/ci-tools without a marker; add a marked image
+  # (docs) and a second unmarked one (tools) to prove the filter + ordering.
+  mkdir -p "${REPO}/images/docs" "${REPO}/images/tools"
+  touch "${REPO}/images/docs/distributable"
+  cd "${REPO}"
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run distributable_images
+  assert_success
+  assert_output "docs"
+}
+
+@test "distributable_images lists multiple marked images, sorted" {
+  touch "${REPO}/images/ci-tools/distributable"
+  mkdir -p "${REPO}/images/aaa"
+  touch "${REPO}/images/aaa/distributable"
+  cd "${REPO}"
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run distributable_images
+  assert_success
+  # Glob order is lexical: aaa before ci-tools.
+  assert_line --index 0 "aaa"
+  assert_line --index 1 "ci-tools"
+}
+
+@test "distributable_images emits nothing when no image is marked" {
+  cd "${REPO}"
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run distributable_images
+  assert_success
+  assert_output ""
+}

--- a/tests/deb/test-all.sh
+++ b/tests/deb/test-all.sh
@@ -2,13 +2,16 @@
 set -euo pipefail
 
 #
-# Build and test all .deb packages locally.
+# Build and test .deb packages for distributable images locally.
 #
-# This script builds .deb packages for all Linux architectures and tests the
-# host-native package in Docker containers before releasing.
+# Discovers the set the same way CI does — every image carrying an
+# images/<name>/distributable marker (scripts/lib/images.sh) — builds its
+# archives + debs, and tests the host-native deb in minimal Debian/Ubuntu
+# containers before releasing.
 #
 # Usage:
-#   ./tests/deb/test-all.sh
+#   ./tests/deb/test-all.sh            # all distributable images
+#   IMAGE=<name> ./tests/deb/test-all.sh   # scope to one (must be distributable)
 #
 # Requirements:
 #   - Docker must be installed and running
@@ -16,7 +19,7 @@ set -euo pipefail
 #
 # Exit codes:
 #   0 - All builds and tests passed
-#   1 - Build or test failed
+#   1 - Build or test failed, or IMAGE is not distributable
 #
 # Notes:
 #   - Only packages matching the host architecture are tested
@@ -26,9 +29,41 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
+# shellcheck source=scripts/lib/images.sh
+source "${REPO_ROOT}/scripts/lib/images.sh"
+
 cd "${REPO_ROOT}"
 
-# Detect host architecture
+# The distributable set (the marker is the opt-in signal), optionally scoped to
+# a single image via IMAGE=. Capture then split — a here-string of "" would
+# yield one empty element, so guard the empty case; the assignment also keeps
+# the function's exit status (unlike piping into mapfile).
+discovered="$(distributable_images)"
+IMAGES=()
+if [[ -n "${discovered}" ]]; then
+  mapfile -t IMAGES <<< "${discovered}"
+fi
+
+if [[ -n "${IMAGE:-}" ]]; then
+  found=0
+  for img in "${IMAGES[@]}"; do
+    [[ "${img}" == "${IMAGE}" ]] && found=1 && break
+  done
+  if [[ "${found}" -ne 1 ]]; then
+    echo "ERROR: '${IMAGE}' is not a distributable image" >&2
+    echo "Add an images/${IMAGE}/distributable marker, or pick one of:" >&2
+    printf '  %s\n' "${IMAGES[@]}" >&2
+    exit 1
+  fi
+  IMAGES=("${IMAGE}")
+fi
+
+if [[ ${#IMAGES[@]} -eq 0 ]]; then
+  echo "No distributable images found (need an images/<name>/distributable marker)." >&2
+  exit 1
+fi
+
+# Detect host architecture — only the matching arch can be installed/run here.
 HOST_ARCH=$(uname -m)
 case "${HOST_ARCH}" in
   x86_64)
@@ -38,68 +73,75 @@ case "${HOST_ARCH}" in
     HOST_DEB_ARCH="arm64"
     ;;
   *)
-    echo "Unknown host architecture: ${HOST_ARCH}"
+    echo "Unknown host architecture: ${HOST_ARCH}" >&2
     exit 1
     ;;
 esac
 
+# Placeholder version — this exercises the packaging pipeline, not a release.
 VERSION="0.0.0"
 ARCHS=(amd64 arm64)
 TEST_IMAGES=(debian:bookworm-slim ubuntu:24.04)
 
-echo "Building and testing ci-tools v${VERSION}"
+echo "Distributable images: ${IMAGES[*]}"
 echo "Host architecture: ${HOST_ARCH} (${HOST_DEB_ARCH})"
 
-# Build all packages
-echo ""
-echo "Staging release artifacts..."
-./scripts/ci-tools/package-release.sh "${VERSION}"
-
-echo ""
-echo "Building deb packages..."
-./scripts/package-deb.sh ci-tools "${VERSION}"
-
-# Test packages
 FAILED=0
 TESTED=0
 
-for arch in "${ARCHS[@]}"; do
-  deb_file="artifacts/release/ci-tools_${VERSION}_${arch}.deb"
+for image in "${IMAGES[@]}"; do
+  echo ""
+  echo "=== ${image} ==="
 
-  if [[ ! -f "${deb_file}" ]]; then
-    echo "ERROR: Package not found: ${deb_file}"
-    FAILED=1
-    continue
-  fi
+  # package-release.sh resets artifacts/{staging,release}, so each image is
+  # packaged in isolation and the only debs present are this image's.
+  echo "Staging release artifacts..."
+  "./scripts/${image}/package-release.sh" "${VERSION}"
 
-  if [[ "${arch}" != "${HOST_DEB_ARCH}" ]]; then
-    echo ""
-    echo "Skipping ${deb_file} (requires ${arch}, host is ${HOST_DEB_ARCH})"
-    continue
-  fi
+  echo "Building deb packages..."
+  "./scripts/package-deb.sh" "${image}" "${VERSION}"
 
-  for test_image in "${TEST_IMAGES[@]}"; do
-    echo ""
-    echo "Testing ${deb_file} on ${test_image}..."
+  for arch in "${ARCHS[@]}"; do
+    # The deb is named from nfpm's `name:` field, not the image name — glob it
+    # rather than assume they match.
+    debs=(artifacts/release/*_"${arch}".deb)
+    deb_file="${debs[0]}"
 
-    if ./tests/deb/test-package.sh ci-tools "${deb_file}" "${test_image}"; then
-      TESTED=$((TESTED + 1))
-    else
-      echo "FAILED: ${arch} on ${test_image}"
+    if [[ ! -f "${deb_file}" ]]; then
+      echo "ERROR: No ${arch} package found for ${image}" >&2
       FAILED=1
+      continue
     fi
+
+    if [[ "${arch}" != "${HOST_DEB_ARCH}" ]]; then
+      echo ""
+      echo "Skipping ${deb_file} (requires ${arch}, host is ${HOST_DEB_ARCH})"
+      continue
+    fi
+
+    for test_image in "${TEST_IMAGES[@]}"; do
+      echo ""
+      echo "Testing ${deb_file} on ${test_image}..."
+
+      if "./tests/deb/test-package.sh" "${image}" "${deb_file}" "${test_image}"; then
+        TESTED=$((TESTED + 1))
+      else
+        echo "FAILED: ${image} ${arch} on ${test_image}" >&2
+        FAILED=1
+      fi
+    done
   done
 done
 
 echo ""
 
 if [[ ${TESTED} -eq 0 ]]; then
-  echo "WARNING: No packages were tested."
+  echo "WARNING: No packages were tested." >&2
   exit 1
 elif [[ ${FAILED} -eq 0 ]]; then
   echo "All tests passed. (${TESTED} tested)"
   exit 0
 else
-  echo "Some tests failed."
+  echo "Some tests failed." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

Auditing the deb/release pipeline against `docs/how-to/add-image.md` surfaced one real behavior gap and several doc inaccuracies. Local package testing (`make test-package`) was hardcoded to `ci-tools` even though every layer it calls — `package-deb.sh`, the `build-deb` action, `tests/deb/test-package.sh` — is already image-generic. This makes the local aggregator discover the distributable set the same way CI does (the `distributable` marker), and rewrites the doc to outline the constructs explicitly and accurately.

## Changes

- Add `distributable_images()` to `scripts/lib/images.sh` — a single discovery helper (marker presence, contents ignored). `scripts/list-distributable-images.sh` now consumes it instead of duplicating the glob.
- Rework `tests/deb/test-all.sh` to discover distributable images via that helper, with `IMAGE=<name>` to scope to one. It's now name-agnostic about the built deb (globs the artifact rather than assuming `<image>_…`), so a package name that differs from the image name still works.
- `make test-package` tests all distributable images by default; `make test-package IMAGE=foo` scopes to one (target-specific empty default overrides the global `IMAGE=ci-tools`).
- Revise `docs/how-to/add-image.md`:
  - Explicit construct outline (incl. `.trivyignore`, `bin/`) and a "How the pipeline finds your image" section documenting the two discovery signals (version stamp → build set; `distributable` marker → packaging set).
  - Correct the "empty marker" wording to presence-only; separate the per-image packaging contract (`package-release.sh`, `verify-deb-install.sh`, `nfpm.yaml`, marker, man page) from the generic machinery.
  - Add `.trivyignore`/scan and `cve-monitor` static-matrix notes.
- Add bats coverage for `distributable_images()`.

## Further Comments

Verified locally: `make lint` and the full bats suite (190) pass, and `make test-package` builds + tests the ci-tools deb end-to-end on Debian and Ubuntu containers (arm64 host).