### PR TITLE
Auto-discover published images in cve-monitor

### DIFF
--- a/.github/workflows/cve-monitor.yml
+++ b/.github/workflows/cve-monitor.yml
@@ -13,8 +13,31 @@ concurrency:
   group: cve-monitor
 
 jobs:
+  discover:
+    name: Discover published images
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    outputs:
+      images: ${{ steps.list.outputs.images }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: List published images
+        id: list
+        # Enumerates images/*/version and keeps those whose :latest probe
+        # succeeds — the scan set is exactly what's published to GHCR. The
+        # knight-owl-dev packages are public, so the probe needs no auth.
+        run: ./scripts/list-published-images.sh
+
   scan:
     name: Scan ${{ matrix.image }}
+    needs: discover
+    if: ${{ needs.discover.outputs.images != '[]' }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -25,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ci-tools] # extend when adding images
+        image: ${{ fromJSON(needs.discover.outputs.images) }}
 
     steps:
       - name: Checkout

--- a/docs/how-to/add-image.md
+++ b/docs/how-to/add-image.md
@@ -57,15 +57,10 @@ re-triage rather than silencing the CVE forever (see
 [suppression workflow](publish-image.md#suppressing-a-cve)). A new image with a
 clean scan needs no such file.
 
-> `cve-monitor.yml` uses a **static** matrix (it scans `:latest`, which has no
-> version stamp to discover). When you add an image, add its name there so the
-> published image is scanned on schedule:
->
-> ```yaml
-> # .github/workflows/cve-monitor.yml
-> matrix:
->   image: [ci-tools, <name>]
-> ```
+> `cve-monitor.yml` **auto-discovers** its scan set: a `discover` job runs
+> `list-published-images.sh`, which enumerates `images/*/version` and keeps the
+> images whose `ghcr.io/knight-owl-dev/<name>:latest` probe succeeds. Once your
+> image has been published, it is scanned on schedule with no workflow edit.
 
 Copy this to the new `.trivyignore.yaml` (replace `<name>`):
 
@@ -209,13 +204,12 @@ image. `make get-version IMAGE=<name>` prints the current stamp. See
 
 ### 9. Wire up workflows
 
-`publish.yml` and `ci.yml` **auto-discover** images — `publish.yml` builds each
-image stamped to the release version (`images/<name>/version == <tag>`) and
-`ci.yml` builds/tests debs for each image with a `distributable` marker — so no
-matrix edit is needed in either.
-
-The one exception is `cve-monitor.yml`, whose static matrix you must extend —
-see [Vulnerability scanning](#vulnerability-scanning) above.
+`publish.yml`, `ci.yml`, and `cve-monitor.yml` all **auto-discover** images —
+`publish.yml` builds each image stamped to the release version
+(`images/<name>/version == <tag>`), `ci.yml` builds/tests debs for each image
+with a `distributable` marker, and `cve-monitor.yml` scans each image whose
+`:latest` is published (see [Vulnerability scanning](#vulnerability-scanning)
+above). No matrix edit is needed in any of them.
 
 ### 10. Add Makefile lint targets (if applicable)
 

--- a/scripts/compute-build-matrix.sh
+++ b/scripts/compute-build-matrix.sh
@@ -29,6 +29,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/version.sh"
 # shellcheck source=scripts/lib/json.sh
 source "${SCRIPT_DIR}/lib/json.sh"
+# shellcheck source=scripts/lib/images.sh
+source "${SCRIPT_DIR}/lib/images.sh"
 
 if [[ $# -ne 1 ]]; then
   echo "Usage: $(basename "$0") <release-version>" >&2
@@ -38,13 +40,19 @@ fi
 # Strict semver, leading v stripped — matches the bare value in version files.
 RELEASE="$(validate_strict_version "$1")"
 
+# Capture then split (a here-string of "" would yield one empty element, so
+# guard the empty case). Assigning the command substitution preserves its exit
+# status, unlike piping into mapfile.
+discovered="$(versioned_images)"
+names=()
+if [[ -n "${discovered}" ]]; then
+  mapfile -t names <<< "${discovered}"
+fi
+
 build=()
 distributable=()
 
-for version_file in images/*/version; do
-  [[ -f "${version_file}" ]] || continue
-  name="$(basename "$(dirname "${version_file}")")"
-
+for name in "${names[@]}"; do
   version="$(read_image_version "${name}")"
 
   if [[ "${version}" == "${RELEASE}" ]]; then

--- a/scripts/lib/images.sh
+++ b/scripts/lib/images.sh
@@ -41,6 +41,24 @@ image_build_context_changed() {
   return 0 # diff => changed
 }
 
+# Echo the names of images that carry a given file under images/<name>/, one per
+# line, in directory order. A missing glob match or a non-file is skipped, so
+# callers get exactly the images whose marker/stamp file is present.
+#
+# Assumes the current working directory is the repo root.
+#
+# Arguments:
+#   $1 - File name to look for under each images/<name>/ directory
+_images_with_file() {
+  local file="$1"
+  local match name
+  for match in images/*/"${file}"; do
+    [[ -f "${match}" ]] || continue
+    name="$(basename "$(dirname "${match}")")"
+    printf '%s\n' "${name}"
+  done
+}
+
 # Echo the names of images carrying a `distributable` marker, one per line, in
 # directory order. The marker's presence is the only signal — its contents are
 # ignored. This is the single opt-in source for everything package-related: the
@@ -49,10 +67,17 @@ image_build_context_changed() {
 #
 # Assumes the current working directory is the repo root.
 distributable_images() {
-  local marker name
-  for marker in images/*/distributable; do
-    [[ -f "${marker}" ]] || continue
-    name="$(basename "$(dirname "${marker}")")"
-    printf '%s\n' "${name}"
-  done
+  _images_with_file distributable
+}
+
+# Echo the names of images carrying a `version` file, one per line, in
+# directory order. The version file is the release stamp every image acquires
+# on its first release; its presence (not its value) is what marks a directory
+# as a real image here. This is the enumerate-images discovery pattern shared by
+# the release build matrix (compute-build-matrix.sh) and the CVE monitor's
+# published-image probe (list-published-images.sh).
+#
+# Assumes the current working directory is the repo root.
+versioned_images() {
+  _images_with_file version
 }

--- a/scripts/lib/registry.sh
+++ b/scripts/lib/registry.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Container registry helpers.
+
+# Test whether an image tag is published in the registry.
+#
+# Returns success if ${REGISTRY}/<name>:<tag> exists. Uses `docker manifest
+# inspect`, which queries the manifest (list) without pulling any layers.
+# REGISTRY defaults to ghcr.io/knight-owl-dev and is overridable (tests stub
+# `docker` on PATH). The knight-owl-dev packages are public, so the probe
+# needs no authentication.
+#
+# Arguments:
+#   $1 - Image name (e.g. "ci-tools")
+#   $2 - Tag (e.g. "latest"); queried verbatim, no normalization
+#
+# Returns:
+#   0 - The tag exists in the registry
+#   1 - The tag is absent, or arguments are missing
+image_tag_published() {
+  if [[ $# -ne 2 ]] || [[ -z "$1" ]] || [[ -z "$2" ]]; then
+    echo "ERROR: image_tag_published requires <name> <tag>" >&2
+    return 1
+  fi
+
+  local name="$1"
+  local tag="$2"
+  local registry="${REGISTRY:-ghcr.io/knight-owl-dev}"
+
+  docker manifest inspect "${registry}/${name}:${tag}" > /dev/null 2>&1
+}

--- a/scripts/list-published-images.sh
+++ b/scripts/list-published-images.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#
+# List the images that are actually published to the registry, as a JSON array.
+#
+# Enumerates images/*/version, then probes ghcr.io/knight-owl-dev/<name>:latest
+# for each and keeps only the images whose probe succeeds. The :latest probe —
+# not the in-tree version stamp — is what makes the set correct: it excludes an
+# image whose release PR merged but whose tag/publish has not completed yet, and
+# guards against a stale or hand-edited stamp that points ahead of the registry.
+# An image is skipped (not failed) when its probe fails, so the scan set is
+# exactly what is currently published.
+#
+# Drives the CVE monitor's scan matrix: coverage tracks what's published, with
+# no static matrix to hand-edit when an image is added.
+#
+# Assumes the current working directory is the repo root.
+#
+# Emits to ${GITHUB_OUTPUT} when set, else stdout:
+#   images=<JSON array of image names>
+#
+# Usage:
+#   ./scripts/list-published-images.sh
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=scripts/lib/json.sh
+source "${SCRIPT_DIR}/lib/json.sh"
+# shellcheck source=scripts/lib/images.sh
+source "${SCRIPT_DIR}/lib/images.sh"
+# shellcheck source=scripts/lib/registry.sh
+source "${SCRIPT_DIR}/lib/registry.sh"
+
+# Capture then split (a here-string of "" would yield one empty element, so
+# guard the empty case). Assigning the command substitution preserves its exit
+# status, unlike piping into mapfile.
+discovered="$(versioned_images)"
+names=()
+if [[ -n "${discovered}" ]]; then
+  mapfile -t names <<< "${discovered}"
+fi
+
+published=()
+for name in "${names[@]}"; do
+  if image_tag_published "${name}" latest; then
+    echo "Including ${name} (:latest is published)" >&2
+    published+=("${name}")
+  else
+    echo "Skipping ${name} (:latest not published)" >&2
+  fi
+done
+
+if [[ ${#published[@]} -gt 0 ]]; then
+  images_json="$(json_array "${published[@]}")"
+else
+  images_json="[]"
+fi
+
+echo "images=${images_json}" >> "${GITHUB_OUTPUT:-/dev/stdout}"

--- a/tests/bats/scripts/lib/images.bats
+++ b/tests/bats/scripts/lib/images.bats
@@ -123,3 +123,28 @@ _commit() {
   assert_success
   assert_output ""
 }
+
+@test "versioned_images lists only images carrying a version file" {
+  # The base repo seeds images/ci-tools with a version file; add a directory
+  # without one (tools) to prove the filter.
+  mkdir -p "${REPO}/images/tools"
+  cd "${REPO}"
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run versioned_images
+  assert_success
+  assert_output "ci-tools"
+}
+
+@test "versioned_images lists multiple images in directory order" {
+  mkdir -p "${REPO}/images/aaa"
+  printf '1.0.0\n' > "${REPO}/images/aaa/version"
+  cd "${REPO}"
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run versioned_images
+  assert_success
+  # Glob order is lexical: aaa before ci-tools.
+  assert_line --index 0 "aaa"
+  assert_line --index 1 "ci-tools"
+}

--- a/tests/bats/scripts/lib/registry.bats
+++ b/tests/bats/scripts/lib/registry.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+#
+# Unit tests for scripts/lib/registry.sh. `docker` is stubbed on PATH so
+# image_tag_published is exercised without touching a real registry; the stub
+# records its arguments so we can assert the queried reference.
+
+load ../../helpers/common
+
+setup() {
+  common_setup
+  LIB="${REPO_ROOT}/scripts/lib/registry.sh"
+  STUB_DIR="${BATS_TEST_TMPDIR}/bin"
+  ARGS_LOG="${BATS_TEST_TMPDIR}/docker-args"
+  mkdir -p "${STUB_DIR}"
+  export LIB STUB_DIR ARGS_LOG
+}
+
+# Install a `docker` stub that records its args and exits with the given code.
+_stub_docker() {
+  local exit_code="$1"
+  cat > "${STUB_DIR}/docker" << EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" > "${ARGS_LOG}"
+exit ${exit_code}
+EOF
+  chmod +x "${STUB_DIR}/docker"
+  export PATH="${STUB_DIR}:${PATH}"
+}
+
+@test "image_tag_published succeeds when manifest inspect succeeds" {
+  _stub_docker 0
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run image_tag_published "ci-tools" "latest"
+  assert_success
+}
+
+@test "image_tag_published fails when manifest inspect fails" {
+  _stub_docker 1
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run image_tag_published "ci-tools" "latest"
+  assert_failure
+}
+
+@test "image_tag_published queries the tag verbatim on the default registry" {
+  _stub_docker 0
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  image_tag_published "ci-tools" "latest"
+  run cat "${ARGS_LOG}"
+  assert_output "manifest inspect ghcr.io/knight-owl-dev/ci-tools:latest"
+}
+
+@test "image_tag_published honors a REGISTRY override" {
+  _stub_docker 0
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  REGISTRY="example.com/org" image_tag_published "ci-tools" "latest"
+  run cat "${ARGS_LOG}"
+  assert_output "manifest inspect example.com/org/ci-tools:latest"
+}
+
+@test "image_tag_published fails with usage when arguments are missing" {
+  _stub_docker 0
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run image_tag_published "ci-tools"
+  assert_failure 1
+  assert_output --partial "requires <name> <tag>"
+}

--- a/tests/bats/scripts/list-published-images.bats
+++ b/tests/bats/scripts/list-published-images.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+#
+# Tests for scripts/list-published-images.sh. The script enumerates
+# images/*/version in the current working directory and probes each image's
+# :latest tag via `docker manifest inspect`. Each test builds a fake images/
+# tree under BATS_TEST_TMPDIR and stubs `docker` on PATH: the stub succeeds only
+# for image names listed in PUBLISHED, so we control exactly which probes pass.
+
+load ../helpers/common
+
+setup() {
+  common_setup
+  SCRIPT="${REPO_ROOT}/scripts/list-published-images.sh"
+  FAKE_REPO="${BATS_TEST_TMPDIR}/repo"
+  STUB_DIR="${BATS_TEST_TMPDIR}/bin"
+  mkdir -p "${FAKE_REPO}" "${STUB_DIR}"
+  unset GITHUB_OUTPUT
+  _stub_docker
+  export SCRIPT FAKE_REPO STUB_DIR
+}
+
+# _seed_image <name> — create images/<name>/version in the fake repo.
+_seed_image() {
+  mkdir -p "${FAKE_REPO}/images/$1"
+  printf '1.0.0\n' > "${FAKE_REPO}/images/$1/version"
+}
+
+# Install a `docker` stub whose `manifest inspect` succeeds only when the probed
+# image name is listed in the PUBLISHED env var (space-separated), failing
+# otherwise — mimicking a registry where only some images have a :latest tag.
+_stub_docker() {
+  cat > "${STUB_DIR}/docker" << 'EOF'
+#!/usr/bin/env bash
+# Last arg is the image ref: ghcr.io/knight-owl-dev/<name>:latest
+ref="${*: -1}"
+name="${ref##*/}"
+name="${name%%:*}"
+for published in ${PUBLISHED:-}; do
+  [[ "${name}" == "${published}" ]] && exit 0
+done
+exit 1
+EOF
+  chmod +x "${STUB_DIR}/docker"
+  export PATH="${STUB_DIR}:${PATH}"
+}
+
+@test "keeps only images whose :latest probe succeeds" {
+  _seed_image ci-tools
+  _seed_image docs
+  cd "${FAKE_REPO}"
+  PUBLISHED="ci-tools" run "${SCRIPT}"
+  assert_success
+  assert_output --partial 'images=["ci-tools"]'
+}
+
+@test "emits an empty array when nothing is published" {
+  _seed_image ci-tools
+  cd "${FAKE_REPO}"
+  PUBLISHED="" run "${SCRIPT}"
+  assert_success
+  assert_output --partial "images=[]"
+}
+
+@test "lists multiple published images in directory order" {
+  _seed_image aaa
+  _seed_image ci-tools
+  cd "${FAKE_REPO}"
+  PUBLISHED="aaa ci-tools" run "${SCRIPT}"
+  assert_success
+  assert_output --partial 'images=["aaa","ci-tools"]'
+}
+
+@test "skips an image whose probe fails but keeps the published ones" {
+  _seed_image ci-tools
+  _seed_image unpublished
+  cd "${FAKE_REPO}"
+  PUBLISHED="ci-tools" run "${SCRIPT}"
+  assert_success
+  assert_output --partial 'images=["ci-tools"]'
+  assert_output --partial "Skipping unpublished"
+  refute_output --partial '"unpublished"'
+}


### PR DESCRIPTION
## Summary

The scheduled CVE monitor scanned a hardcoded matrix that had to be hand-edited whenever an image was added — an easy step to forget, leaving a published image silently unscanned. This makes the monitor discover its scan set automatically, so coverage tracks exactly what's published to GHCR with no manual step.

## Related Issues

Fixes #147

## Changes

- `discover` job in `cve-monitor.yml` feeds the scan matrix via `fromJSON`; the static `[ci-tools]` matrix is dropped.
- New `scripts/list-published-images.sh`: enumerate `images/*/version`, probe `ghcr.io/knight-owl-dev/<name>:latest`, keep only the images whose probe succeeds (skip-on-error, logged).
- Re-introduced `scripts/lib/registry.sh` with a focused `image_tag_published <name> <tag>` (anonymous `docker manifest inspect`).
- Added `versioned_images()` plus a shared `_images_with_file()` helper in `scripts/lib/images.sh`, and refactored `compute-build-matrix.sh` onto it.
- Bats: new `registry` and `list-published-images` suites; extended `images.bats`.
- `docs/how-to/add-image.md`: dropped the manual "extend the static matrix" step — all workflows now auto-discover.

## Further Comments

Gating on the `:latest` probe (not the in-tree `version` stamp, not the `distributable` set) is deliberate: non-distributable images like `docs` are still scanned, and a stamp that's ahead of the registry can't blind the monitor while `:latest` still points at the prior build.

GHCR `knight-owl-dev` packages are public, so the probe runs anonymously — consistent with how the existing Trivy scan already pulls `:latest`. Only `ci-tools` exists in-tree today, so the discovered set is currently `["ci-tools"]`; the machinery picks up future images automatically.