### PR TITLE
Add `make release BUMP=patch|minor|major` for next-version releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,25 @@
 name: Release
 
 # Open a release PR: stamp every image whose build context changed since its
-# last release to the given version, on a release/vX.Y.Z branch. Merging that PR
-# promotes tag vX.Y.Z (see tag-release.yml), which triggers the publish workflow.
+# last release, on a release/vX.Y.Z branch. The version is bumped from the
+# latest release tag (bump) or set explicitly (version, which wins if set).
+# Merging that PR promotes tag vX.Y.Z (see tag-release.yml), which triggers the
+# publish workflow.
 
 on:
   workflow_dispatch:
     inputs:
+      bump:
+        description: "Bump from the latest release tag"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
       version:
-        description: "Release version (e.g. 1.3.0)"
-        required: true
+        description: "Explicit version (e.g. 1.3.0); overrides bump if set"
+        required: false
         type: string
       automerge:
         description: "Auto-merge the release PR once checks pass"
@@ -46,5 +56,12 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           VERSION: ${{ inputs.version }}
+          BUMP: ${{ inputs.bump }}
           AUTOMERGE: ${{ inputs.automerge && '1' || '' }}
-        run: make release VERSION="${VERSION}"
+        # An explicit version wins; otherwise bump from the latest release tag.
+        run: |
+          if [ -n "${VERSION}" ]; then
+            make release VERSION="${VERSION}"
+          else
+            make release BUMP="${BUMP}"
+          fi

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,13 @@ set-version:
 get-version:
 	@scripts/get-image-version.sh $(IMAGE)
 
-# Open a release PR: stamp images that changed since their last release to
-# VERSION and open "Release vVERSION" (merging it promotes the tag). Pass
-# AUTOMERGE=1 to enable auto-merge once checks pass.
+# Open a release PR: stamp images that changed since their last release and
+# open "Release vVERSION" (merging it promotes the tag). The version is either
+# bumped from the latest release tag (BUMP=patch|minor|major) or set explicitly
+# (VERSION=X.Y.Z, which wins if both are given). Pass AUTOMERGE=1 to enable
+# auto-merge once checks pass.
 release:
-	@AUTOMERGE='$(AUTOMERGE)' scripts/release.sh $(VERSION)
+	@AUTOMERGE='$(AUTOMERGE)' scripts/release.sh $(if $(VERSION),$(VERSION),$(BUMP))
 
 # Build image locally
 build:
@@ -160,7 +162,8 @@ help:
 	@echo "  make resolve TOOLS=... Pin specific tools (e.g. shfmt:v3.11.0)*"
 	@echo "  make set-version VERSION=1.3.0  Set images/\$$(IMAGE)/version"
 	@echo "  make get-version       Print images/\$$(IMAGE)/version"
-	@echo "  make release VERSION=1.3.0  Open a release PR for changed images"
+	@echo "  make release BUMP=patch    Open a release PR, version bumped from latest tag"
+	@echo "  make release VERSION=1.3.0 Open a release PR at an explicit version"
 	@echo "  make build             Build image locally"
 	@echo "  make verify            Verify all tools in the built image"
 	@echo "  make scan              Scan image for vulnerabilities"

--- a/README.md
+++ b/README.md
@@ -80,14 +80,19 @@ jobs:
 
 ### Releasing
 
-A release is a reviewable PR, not a manual tag. `make release VERSION=X.Y.Z`
-stamps every image whose build context changed since its last release and opens
-a `release/vX.Y.Z` PR. Merging that PR promotes tag `vX.Y.Z` automatically,
-which triggers the `publish` workflow.
+A release is a reviewable PR, not a manual tag. `make release BUMP=patch`
+derives the next version from the latest release tag, stamps every image whose
+build context changed since its last release, and opens a `release/vX.Y.Z` PR.
+Merging that PR promotes tag `vX.Y.Z` automatically, which triggers the
+`publish` workflow.
 
 ```bash
-make release VERSION=1.3.0   # opens the release PR (review the stamp diff, then merge)
+make release BUMP=patch       # 1.2.7 → 1.2.8 (BUMP=minor → 1.3.0, BUMP=major → 2.0.0)
+make release VERSION=2.0.0    # explicit version, for jumps or corrections
 ```
+
+The bump base is the highest release tag, so there is no separate version file
+to keep in sync. `VERSION=` overrides `BUMP=` when both are given.
 
 Because the per-image `images/<name>/version` is the release at which the image
 last changed, the release tag, package version, and image tag are always one

--- a/docs/how-to/add-image.md
+++ b/docs/how-to/add-image.md
@@ -195,12 +195,15 @@ directory with a `Dockerfile` and no prior release) is detected as changed and
 stamped on the next release:
 
 ```bash
-make release VERSION=0.1.0   # opens a "Release v0.1.0" PR stamping changed images
+make release BUMP=patch   # opens the next-version release PR, stamping changed images
 ```
 
-Merging that release PR promotes tag `v0.1.0`, which builds and publishes the
-image. `make get-version IMAGE=<name>` prints the current stamp. See
-[Publish an Image](publish-image.md) for the full release flow.
+The release version is repo-wide (one tag per release), so a new image is
+stamped to that next version alongside any other changed images rather than
+getting an independent number. Merging the release PR promotes the tag, which
+builds and publishes the image. `make get-version IMAGE=<name>` prints the
+current stamp. See [Publish an Image](publish-image.md) for the full release
+flow.
 
 ### 9. Wire up workflows
 

--- a/docs/how-to/publish-image.md
+++ b/docs/how-to/publish-image.md
@@ -16,12 +16,16 @@ Releases are maintainer-triggered and reviewed as a PR:
    `workflow_dispatch`:
 
    ```bash
-   make release VERSION=1.3.0
+   make release BUMP=patch      # bump from the latest release tag (minor|major too)
+   make release VERSION=1.3.0   # or set the version explicitly
    ```
 
-   This stamps `images/<name>/version` to `1.3.0` for every image whose build
-   context changed since its last release, on a `release/v1.3.0` branch, and
-   opens a "Release v1.3.0" PR. It refuses if a release PR is already open —
+   `BUMP=` derives the next version from the highest release tag (`patch`,
+   `minor`, or `major`, resetting lower components to zero); `VERSION=` sets it
+   explicitly and wins if both are given. Either way this stamps
+   `images/<name>/version` to the resolved version for every image whose build
+   context changed since its last release, on a `release/vX.Y.Z` branch, and
+   opens a "Release vX.Y.Z" PR. It refuses if a release PR is already open —
    close or merge that one first. Pass `AUTOMERGE=1` (or the workflow's
    `automerge` input) to merge automatically once checks pass.
 

--- a/scripts/lib/version.sh
+++ b/scripts/lib/version.sh
@@ -52,6 +52,81 @@ validate_strict_version() {
   echo "${version}"
 }
 
+# Echo the highest strict-semver version from newline-separated stdin.
+#
+# Keeps only bare or "v"-prefixed MAJOR.MINOR.PATCH lines, discarding
+# everything else (pre-releases like v1.0.0-rc1, branch-style refs), and
+# echoes the greatest by semver order with any "v" stripped. Echoes
+# "0.0.0" when no strict-semver line is present, so a fresh repo with no
+# release tags yields a sane bump base.
+#
+# Reads candidates from stdin (e.g. `git tag --list 'v*' | max_strict_version`)
+# so the git I/O lives in the caller, keeping this pure and testable.
+#
+# Outputs:
+#   The highest bare version string, or "0.0.0"
+#
+# Returns:
+#   0 - Always
+max_strict_version() {
+  local candidates sorted highest
+  candidates="$(grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$')" || candidates=""
+
+  if [[ -z "${candidates}" ]]; then
+    echo "0.0.0"
+    return 0
+  fi
+
+  sorted="$(sort -V <<< "${candidates}")"
+  highest="$(tail -n1 <<< "${sorted}")"
+  echo "${highest#v}"
+}
+
+# Compute the next strict-semver version by bumping one component.
+#
+# Bumping a component resets all lower ones to zero: a major bump zeroes
+# minor and patch; a minor bump zeroes patch.
+#
+# Arguments:
+#   $1 - Current version (strict semver, optional leading "v")
+#   $2 - Component to bump: major | minor | patch
+#
+# Outputs:
+#   The bumped bare version string on success
+#
+# Returns:
+#   0 - Success
+#   1 - Invalid current version or unknown component
+bump_version() {
+  local current component major minor patch
+  current="$(validate_strict_version "${1:-}")" || return 1
+  component="${2:-}"
+
+  IFS=. read -r major minor patch <<< "${current}"
+
+  case "${component}" in
+    major)
+      major=$((major + 1))
+      minor=0
+      patch=0
+      ;;
+    minor)
+      minor=$((minor + 1))
+      patch=0
+      ;;
+    patch)
+      patch=$((patch + 1))
+      ;;
+    *)
+      echo "ERROR: Unknown bump component: ${component:-(none)}" >&2
+      echo "Expected: major | minor | patch" >&2
+      return 1
+      ;;
+  esac
+
+  echo "${major}.${minor}.${patch}"
+}
+
 # Read and validate an image's in-tree version.
 #
 # Reads the first line of <images-dir>/<name>/version and runs it through

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 # (.github/workflows/tag-release.yml), which triggers the publish workflow.
 #
 # Usage:
-#   ./scripts/release.sh <version>
+#   ./scripts/release.sh <major|minor|patch>   # bump latest release tag
+#   ./scripts/release.sh <X.Y.Z>               # explicit version (escape hatch)
 #
 # Environment:
 #   GH_TOKEN           (CI) GitHub App token used for push + PR creation, so the
@@ -30,14 +31,33 @@ source "${SCRIPT_DIR}/lib/version.sh"
 source "${SCRIPT_DIR}/lib/images.sh"
 
 if [[ $# -ne 1 ]]; then
-  echo "Usage: $(basename "$0") <version>" >&2
+  echo "Usage: $(basename "$0") <major|minor|patch|X.Y.Z>" >&2
   exit 1
 fi
 
-# Strict semver, leading v stripped.
-VERSION="$(validate_strict_version "$1")"
-
 cd "${REPO_ROOT}"
+
+# Best-effort refresh of tags before any tag-derived work: a bump verb reads
+# them for the next-version base, and the per-image diff below uses them as the
+# build-context baseline. Offline is tolerated (existing local tags are used).
+git fetch --tags --quiet 2> /dev/null || true
+
+# Resolve the target version. A bump verb derives the next version from the
+# latest release tag — the same source publish.yml keys off, so there is no
+# second source of truth to drift. An explicit X.Y.Z is the escape hatch for
+# version jumps or corrections.
+case "$1" in
+  major | minor | patch)
+    tags="$(git tag --list 'v*')"
+    current="$(max_strict_version <<< "${tags}")"
+    VERSION="$(bump_version "${current}" "$1")"
+    echo "Latest release v${current} → bumping $1 → v${VERSION}"
+    ;;
+  *)
+    # Strict semver, leading v stripped.
+    VERSION="$(validate_strict_version "$1")"
+    ;;
+esac
 
 # Require a clean tree: the stamp bumps must be the only changes in the release PR.
 if ! git diff --quiet || ! git diff --staged --quiet; then
@@ -57,9 +77,6 @@ if [[ -n "${existing}" ]]; then
   echo "ERROR: An open release PR already exists (#${existing}) — close or merge it before cutting another." >&2
   exit 1
 fi
-
-# Best-effort refresh of tags so the per-image diff base is current.
-git fetch --tags --quiet 2> /dev/null || true
 
 # Determine which images changed since their last release stamp.
 changed=()

--- a/tests/bats/scripts/lib/version.bats
+++ b/tests/bats/scripts/lib/version.bats
@@ -166,3 +166,112 @@ _seed_version() {
   assert_failure 1
   assert_output --partial "Image name required"
 }
+
+# ── max_strict_version ───────────────────────────────────────────────
+
+@test "max_strict_version echoes the highest of several tags, v-stripped" {
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run max_strict_version <<< $'v1.2.7\nv1.3.0\nv1.2.10'
+  assert_success
+  assert_output "1.3.0"
+}
+
+@test "max_strict_version orders by semver, not lexically" {
+  # 1.2.10 > 1.2.9 numerically, but sorts lower as a string.
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run max_strict_version <<< $'v1.2.9\nv1.2.10'
+  assert_success
+  assert_output "1.2.10"
+}
+
+@test "max_strict_version ignores pre-releases and non-version lines" {
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run max_strict_version <<< $'v1.3.0\nv2.0.0-rc1\nrelease/v1.9.0\nlatest'
+  assert_success
+  assert_output "1.3.0"
+}
+
+@test "max_strict_version accepts bare versions without a v prefix" {
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run max_strict_version <<< $'1.2.7\n1.4.1'
+  assert_success
+  assert_output "1.4.1"
+}
+
+@test "max_strict_version echoes 0.0.0 when no strict version is present" {
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run max_strict_version <<< $'latest\nmain\nv2.0.0-beta'
+  assert_success
+  assert_output "0.0.0"
+}
+
+@test "max_strict_version echoes 0.0.0 for empty input" {
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run max_strict_version < /dev/null
+  assert_success
+  assert_output "0.0.0"
+}
+
+# ── bump_version ─────────────────────────────────────────────────────
+
+@test "bump_version patch increments the patch component" {
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run bump_version "1.2.7" patch
+  assert_success
+  assert_output "1.2.8"
+}
+
+@test "bump_version minor increments minor and resets patch to zero" {
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run bump_version "1.2.7" minor
+  assert_success
+  assert_output "1.3.0"
+}
+
+@test "bump_version major increments major and resets minor and patch to zero" {
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run bump_version "1.2.7" major
+  assert_success
+  assert_output "2.0.0"
+}
+
+@test "bump_version strips a leading v prefix from the current version" {
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run bump_version "v1.2.7" patch
+  assert_success
+  assert_output "1.2.8"
+}
+
+@test "bump_version rejects an unknown component" {
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run bump_version "1.2.7" build
+  assert_failure 1
+  assert_output --partial "Unknown bump component"
+}
+
+@test "bump_version rejects a missing component" {
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run bump_version "1.2.7"
+  assert_failure 1
+  assert_output --partial "Unknown bump component"
+}
+
+@test "bump_version rejects a malformed current version" {
+  # shellcheck disable=SC1090
+  source "${LIB}"
+  run bump_version "1.2" patch
+  assert_failure 1
+  assert_output --partial "Invalid strict version"
+}


### PR DESCRIPTION
## Summary

Cutting a release no longer requires looking up the latest tag and hand-computing the next number. `make release BUMP=patch` (or `minor`/`major`) derives the next version from the highest release tag and opens the release PR as before. The bump base is the git tag — the same source `publish.yml` already keys off — so no second source of truth is introduced and nothing can drift. `VERSION=X.Y.Z` stays as an explicit escape hatch for jumps or corrections and wins if both are given.

## Related Issues

Fixes #161

## Changes

- Add `max_strict_version` (pure, stdin-fed) and `bump_version` (resets all lower components to zero) to `scripts/lib/version.sh`, keeping git I/O in the caller per the single-responsibility convention.
- Teach `scripts/release.sh` to accept `major|minor|patch` or an explicit `X.Y.Z`, and hoist the tag fetch so the bump base and per-image diff base share one refresh.
- Wire `BUMP` through the `Makefile` (`VERSION=` wins when both are set) and add a `bump` choice input to the `release.yml` workflow (`version` becomes the optional override).
- Extend `version.bats` with coverage for both new helpers.
- Update README, publish-image, and add-image docs to lead with `BUMP=` and note that tags remain authoritative.

## Further Comments

The bump/selection logic is pure and unit-tested (30/30 `version.bats` pass). Verified against the live repo state: `1.2.7 → patch 1.2.8 / minor 1.3.0 / major 2.0.0`. `make -n` confirms `VERSION` precedence and that a bare `make release` falls through to the script's usage error.