### PR TITLE
Drop redundant title line from the release PR body

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -133,7 +133,7 @@ git commit -m "Release v${VERSION}"
 git push -u origin "${BRANCH}"
 
 body="$(
-  printf 'Release v%s.\n\nImages stamped to v%s:\n' "${VERSION}" "${VERSION}"
+  printf 'Images stamped to v%s:\n' "${VERSION}"
   printf -- '- %s\n' "${changed[@]}"
   printf '\nMerging this PR promotes tag v%s, which publishes the stamped images.\n' "${VERSION}"
 )"


### PR DESCRIPTION
## Summary

The generated release PR body opened with `Release vX.Y.Z.`, which restates the PR title verbatim and adds nothing. Lead with the `Images stamped to vX.Y.Z:` line instead, so every line in the body conveys something the title doesn't. The remaining two version mentions are kept deliberately — one names which images were stamped, the other names the tag the merge promotes.

## Changes

- `scripts/release.sh`: drop the title-restating opening line from the PR body template.

## Further Comments

Cosmetic follow-up to #162. Affects only the body text `gh pr create` produces for future `release/v*` PRs; no behavior change.