### PR TITLE
Pin libssl3/openssl to deb12u2 to fix CVE-2026-45447

### DIFF
--- a/images/ci-tools/Dockerfile
+++ b/images/ci-tools/Dockerfile
@@ -9,11 +9,19 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # CVE-2026-3833, and CVE-2026-42009. Remove once the base image ships
 # libgnutls30 >= 3.7.9-2+deb12u7. Tracking issue: #135.
 #
+# libssl3 and openssl are listed explicitly to force apt to pull the deb12u2
+# revision, fixing CVE-2026-45447 (heap use-after-free in PKCS7_verify()).
+# Both arrive transitively via curl/git/gnupg; naming them forces the patched
+# build. Remove once the base image ships openssl >= 3.0.20-1~deb12u2.
+# Tracking issue: #173.
+#
 # DL3008: apt packages are intentionally unpinned
 # hadolint ignore=DL3008
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     libgnutls30 \
+    libssl3 \
+    openssl \
     shellcheck \
     chktex \
     mandoc \

--- a/images/docs/Dockerfile
+++ b/images/docs/Dockerfile
@@ -13,11 +13,18 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # CVE-2026-3833, and CVE-2026-42009. Remove once the base image ships
 # libgnutls30 >= 3.7.9-2+deb12u7. Tracking issue: #135.
 #
+# libssl3 and openssl are listed explicitly to force apt to pull the deb12u2
+# revision, fixing CVE-2026-45447 (heap use-after-free in PKCS7_verify()).
+# Remove once the base image ships openssl >= 3.0.20-1~deb12u2. Tracking
+# issue: #173.
+#
 # DL3008: apt packages are intentionally unpinned
 # hadolint ignore=DL3008
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     libgnutls30 \
+    libssl3 \
+    openssl \
     make \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

The scheduled CVE monitor flagged a fixable HIGH vulnerability (CVE-2026-45447, a heap use-after-free in OpenSSL's PKCS7_verify()) in both the published `ci-tools` and `docs` images. Debian shipped the fix in the `deb12u2` revision, but the upstream base images still carry `deb12u1`, so the patched build isn't picked up automatically. This pins `libssl3` and `openssl` to the patched revision in both images, clearing the scan.

## Related Issues

Fixes #171
Fixes #172
Refs #173

## Changes

- Explicitly list `libssl3` and `openssl` in the `apt-get install` lists for the `docs` and `ci-tools` images, forcing apt to pull the `deb12u2` revision. Mirrors the existing `libgnutls30` workaround.
- Document the removal condition (base images shipping `openssl >= 3.0.20-1~deb12u2`) in both Dockerfile comment blocks, referencing tracking issue #173.

## Further Comments

Verified locally with `make build` + `make scan` for both images — the debian OS layer now reports 0 findings (was 2 HIGH each). Tracking issue #173 covers removing the explicit pins once the base images catch up, matching the #135 pattern for `libgnutls30`.