### PR TITLE
Restore zip/unzip in ci-tools image

### DIFF
--- a/images/ci-tools/Dockerfile
+++ b/images/ci-tools/Dockerfile
@@ -63,6 +63,8 @@ RUN apt-get update \
     git \
     gnupg \
     xmlstarlet \
+    zip \
+    unzip \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/images/ci-tools/README.md
+++ b/images/ci-tools/README.md
@@ -26,9 +26,11 @@ CI pipelines. Published to GHCR at `ghcr.io/knight-owl-dev/ci-tools`.
 | [shellcheck](https://github.com/koalaman/shellcheck) | Shell script linting |
 | [shfmt](https://github.com/mvdan/sh) | Shell script formatting |
 | [stylelint](https://github.com/stylelint/stylelint) | CSS linting |
+| [unzip](https://infozip.sourceforge.net) | Archive extraction for archive-format test fixtures (ODT/DOCX/EPUB) |
 | validate-action-pins | GitHub Actions SHA pin verification |
 | [xmlstarlet](https://xmlstar.sourceforge.net) | XML querying and editing |
 | [yq](https://github.com/mikefarah/yq) | YAML/JSON/XML processing |
+| [zip](https://infozip.sourceforge.net) | Archive assembly for archive-format test fixtures (ODT/DOCX/EPUB) |
 
 Pinned versions and checksums are tracked in
 [`versions.lock`](versions.lock).

--- a/scripts/ci-tools/verify.sh
+++ b/scripts/ci-tools/verify.sh
@@ -58,6 +58,8 @@ check "gpg" "" gpg --version
 check "make" "" make --version
 check "parallel" "" parallel --version
 check "xmlstarlet" "" xmlstarlet --version
+check "zip" "" zip -v
+check "unzip" "" unzip -v
 check "locale-en-us" "" bash -c "locale -a | grep -q en_US.utf8"
 check "lc-all-default" "C" printenv LC_ALL
 verify_exit


### PR DESCRIPTION
## Summary

The Lua 5.4 rebuild (#189) dropped `zip` and `unzip` from `ci-tools:latest`, breaking downstream bats suites that assemble and inspect archive-format fixtures (ODT/DOCX/EPUB). This restores both so the image honors its tool contract again.

## Related Issues

Fixes #192

## Changes

- Request `zip` and `unzip` explicitly in the final-stage apt block. They had only ever been present as transitive deps of `luarocks`, which #189 moved to the throwaway builder stage — so they silently disappeared.
- Assert both in `scripts/ci-tools/verify.sh` so a future dependency shuffle fails `make verify` instead of surfacing downstream as status 127.
- List both in the README tool inventory.

## Further Comments

Verified by inspection against the pre-5.4 Dockerfile, which confirms `luarocks`/`gcc` (and their transitive `zip`/`unzip`) lived in the final image before #189. The live check runs in `publish.yml`, which builds the updated image single-platform and runs `make verify` against it. PR CI's lint/bats jobs run inside the stale published image but don't touch these tools.