### PR TITLE
Enforce spell checking on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Lint
-        # cspell ships in the next release; the published image CI runs inside
-        # does not have it yet. Drop SKIP once that release is out — see #207.
-        run: make lint SKIP=lint-spell
+        run: make lint
 
   bats:
     name: BATS

--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ scan: build
 		--exit-code 1 \
 		$(IMAGE_TAG)
 
-# Run all linters. SKIP='lint-a lint-b' drops targets from the run — needed
-# when a linter's tool is not yet in the published image CI runs inside.
+# Run all linters. SKIP='lint-a lint-b' drops targets from the run — bootstraps
+# a linter whose tool is not yet in the published image CI runs inside.
 LINT_TARGETS := lint-lockfile lint-docker lint-sh lint-sh-fmt lint-actions \
 	lint-md lint-spell lint-man
 lint: $(filter-out $(SKIP),$(LINT_TARGETS))


### PR DESCRIPTION
## Summary

v1.4.0 published `cspell` in ci-tools, so the image CI runs inside now carries it. Spelling was the one linter not enforced on PRs; this closes that gap.

## Related Issues

Fixes #207

## Changes

- `.github/workflows/ci.yml` runs `make lint` again, without `SKIP=lint-spell`
- Reworded the `SKIP` comment in the Makefile — the mechanism stays for the next linter needing the same bootstrap

## Further Comments

Confirmed by running `make lint` inside `ghcr.io/knight-owl-dev/ci-tools:latest`, which is what the CI job does: spell check runs over 105 files with 0 issues.
