### PR TITLE
Suppress npm-vendored ci-tools CVEs and add scan NO_IGNORE mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,17 +53,25 @@ verify:
 		-v $(CURDIR)/images/$(IMAGE)/versions.lock:/versions.lock:ro \
 		$(IMAGE_TAG) /scripts/$(IMAGE)/verify.sh
 
-# Scan image for vulnerabilities
+# Scan image for vulnerabilities. NO_IGNORE=1 drops the suppression file to
+# report what .trivyignore.yaml hides, and drops --exit-code with it so the
+# report doesn't fail the build.
+ifndef NO_IGNORE
+TRIVY_IGNORE_MOUNT := -v $(CURDIR)/images/$(IMAGE)/.trivyignore.yaml:/.trivyignore.yaml:ro
+TRIVY_IGNORE_FLAG := --ignorefile /.trivyignore.yaml
+TRIVY_EXIT_CODE := --exit-code 1
+endif
+
 scan: build
-	@echo "Scanning $(IMAGE_TAG) for vulnerabilities..."
+	@echo "Scanning $(IMAGE_TAG) for vulnerabilities$(if $(NO_IGNORE), (suppressions disabled),)..."
 	@docker run --rm $(DOCKER_TTY) \
 		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v $(CURDIR)/images/$(IMAGE)/.trivyignore.yaml:/.trivyignore.yaml:ro \
-		aquasec/trivy:0.72.0 image \
-		--ignorefile /.trivyignore.yaml \
+		$(TRIVY_IGNORE_MOUNT) \
+		aquasec/trivy:0.73.0 image \
+		$(TRIVY_IGNORE_FLAG) \
 		--severity CRITICAL,HIGH \
 		--ignore-unfixed \
-		--exit-code 1 \
+		$(TRIVY_EXIT_CODE) \
 		$(IMAGE_TAG)
 
 # Run all linters. SKIP='lint-a lint-b' drops targets from the run — bootstraps
@@ -174,6 +182,7 @@ help:
 	@echo "  make build             Build image locally"
 	@echo "  make verify            Verify all tools in the built image"
 	@echo "  make scan              Scan image for vulnerabilities"
+	@echo "  make scan NO_IGNORE=1  Scan without .trivyignore.yaml suppressions"
 	@echo "  make clean             Remove local image"
 	@echo "  make lint              Run all linters"
 	@echo "  make lint SKIP=...     Run all linters except the named targets"

--- a/docs/how-to/publish-image.md
+++ b/docs/how-to/publish-image.md
@@ -223,6 +223,9 @@ scheduled CVE monitor). Re-triage it:
 - If not, **extend** `expired_at` with a fresh justification in the
   `statement`.
 
+An entry can also clear before `expired_at`. `make scan NO_IGNORE=1` reports
+every CVE the file suppresses, surfacing any that upstream has since fixed.
+
 Keep `trivyignores:` pointed at a **single** YAML file per image — the
 trivy-action concatenates a mixed list into an extensionless temp file that
 Trivy parses as plain text, silently dropping the structured entries.

--- a/images/ci-tools/.trivyignore.yaml
+++ b/images/ci-tools/.trivyignore.yaml
@@ -26,7 +26,7 @@ vulnerabilities:
       1.26.1) — offline lint/format tools with no untrusted network or
       certificate input, so practical risk is negligible. Tracking: #96.
       Remove once both ship builds on Go >= 1.25.9 or 1.26.2.
-    expired_at: 2026-09-01
+    expired_at: 2026-09-25
 
   - id: CVE-2026-32281
     statement: >-
@@ -35,7 +35,7 @@ vulnerabilities:
       1.26.1) — offline lint/format tools with no untrusted network or
       certificate input, so practical risk is negligible. Tracking: #96.
       Remove once both ship builds on Go >= 1.25.9 or 1.26.2.
-    expired_at: 2026-09-01
+    expired_at: 2026-09-25
 
   - id: CVE-2026-32283
     statement: >-
@@ -44,7 +44,7 @@ vulnerabilities:
       1.26.1) — offline lint/format tools that open no TLS sessions to
       untrusted peers, so practical risk is negligible. Tracking: #96.
       Remove once both ship builds on Go >= 1.25.9 or 1.26.2.
-    expired_at: 2026-09-01
+    expired_at: 2026-09-25
 
   - id: CVE-2026-33810
     statement: >-
@@ -54,7 +54,7 @@ vulnerabilities:
       no X.509 chains against untrusted input, so practical risk is
       negligible. Tracking: #96. Remove once both ship builds on Go >=
       1.26.2.
-    expired_at: 2026-09-01
+    expired_at: 2026-09-25
 
   - id: CVE-2026-33811
     statement: >-
@@ -63,7 +63,7 @@ vulnerabilities:
       shfmt v3.13.1 (Go 1.26.1) — offline lint/format tools that resolve no
       untrusted hostnames, so practical risk is negligible. Tracking: #96.
       Remove once both ship builds on Go >= 1.25.10 or 1.26.3.
-    expired_at: 2026-09-01
+    expired_at: 2026-09-25
 
   - id: CVE-2026-33814
     statement: >-
@@ -72,7 +72,7 @@ vulnerabilities:
       (Go 1.26.1) — offline lint/format tools that serve no HTTP/2 to
       untrusted peers, so practical risk is negligible. Tracking: #96.
       Remove once both ship builds on Go >= 1.25.10 or 1.26.3.
-    expired_at: 2026-09-01
+    expired_at: 2026-09-25
 
   - id: CVE-2026-39820
     statement: >-
@@ -81,7 +81,7 @@ vulnerabilities:
       v3.13.1 (Go 1.26.1) — offline lint/format tools that parse no
       untrusted mail addresses, so practical risk is negligible. Tracking:
       #96. Remove once both ship builds on Go >= 1.25.10 or 1.26.3.
-    expired_at: 2026-09-01
+    expired_at: 2026-09-25
 
   - id: CVE-2026-39822
     statement: >-
@@ -91,7 +91,7 @@ vulnerabilities:
       that confine no untrusted filesystem paths via os.Root, so practical
       risk is negligible. Tracking: #96. Remove once all three ship builds
       on Go >= 1.25.12 or 1.26.5.
-    expired_at: 2026-09-01
+    expired_at: 2026-09-25
 
   - id: CVE-2026-39836
     statement: >-
@@ -100,7 +100,7 @@ vulnerabilities:
       v3.13.1 (Go 1.26.1) — offline lint/format tools that dial no
       untrusted addresses, so practical risk is negligible. Tracking: #96.
       Remove once both ship builds on Go >= 1.25.10 or 1.26.3.
-    expired_at: 2026-09-01
+    expired_at: 2026-09-25
 
   - id: CVE-2026-42499
     statement: >-
@@ -109,7 +109,7 @@ vulnerabilities:
       1.26.1) — offline lint/format tools that parse no untrusted mail
       addresses, so practical risk is negligible. Tracking: #96. Remove
       once both ship builds on Go >= 1.25.10 or 1.26.3.
-    expired_at: 2026-09-01
+    expired_at: 2026-09-25
 
   - id: CVE-2026-42504
     statement: >-
@@ -118,7 +118,7 @@ vulnerabilities:
       (Go 1.26.1) — offline lint/format tools that decode no untrusted MIME
       headers, so practical risk is negligible. Tracking: #96. Remove once
       both ship builds on Go >= 1.25.11 or 1.26.4.
-    expired_at: 2026-09-01
+    expired_at: 2026-09-25
 
   - id: CVE-2026-27145
     statement: >-
@@ -128,7 +128,7 @@ vulnerabilities:
       lint/format tools that verify no certificates against untrusted input,
       so practical risk is negligible. Tracking: #96. Remove once both ship
       builds on Go >= 1.25.11 or 1.26.4.
-    expired_at: 2026-09-01
+    expired_at: 2026-09-25
 
   - id: CVE-2026-14257
     statement: >-
@@ -137,7 +137,27 @@ vulnerabilities:
       which still bundles 5.0.7 — npm expands globs over repo-local paths
       at build time, never attacker-supplied patterns, so practical risk is
       negligible. Tracking: #203. Remove once npm bundles >= 5.0.8.
-    expired_at: 2026-09-01
+    expired_at: 2026-09-25
+
+  - id: CVE-2026-69152
+    statement: >-
+      brace-expansion DoS — expand() skips maxLength on intermediate arrays
+      and padded sequences, bypassing the CVE-2026-14257 fix. Fixed in 5.0.9.
+      Reaches npm 12.0.2 via minimatch, which still resolves 5.0.7 — npm
+      expands globs over repo-local paths at build time, never
+      attacker-supplied patterns, so practical risk is negligible. Tracking:
+      #203. Remove once npm bundles >= 5.0.9.
+    expired_at: 2026-09-25
+
+  - id: CVE-2026-69192
+    statement: >-
+      ip-address decodes a leading-zero octet as decimal where the network
+      stack reads it as octal, so an SSRF filter built on isPrivate() can be
+      bypassed. Fixed in 10.3.1. Reaches npm 12.0.2 via socks-proxy-agent,
+      which parses an address only when a SOCKS proxy is configured — none is
+      here, so practical risk is negligible. Tracking: #203. Remove once npm
+      bundles >= 10.3.1.
+    expired_at: 2026-09-25
 
   - id: CVE-2026-56852
     statement: >-
@@ -146,4 +166,4 @@ vulnerabilities:
       against v0.37.0 — yq reads only repo-controlled YAML here, so
       practical risk is negligible. Tracking: #203. Remove once yq ships a
       build against x/text >= 0.39.0.
-    expired_at: 2026-09-01
+    expired_at: 2026-09-25


### PR DESCRIPTION
## Summary

Clears the two fixable HIGH findings the CVE monitor raised against the published ci-tools image. Both are vendored into npm's own `node_modules`, and npm is already at its newest release, so neither clears by bumping a tool — both are suppressed behind #203. Retriaging them meant scanning with the ignorefile off, the same manual step #204 took, so that is now `make scan NO_IGNORE=1`.

## Related Issues

Fixes #213
Refs #203

## Changes

- Suppress CVE-2026-69152 (brace-expansion, reached via minimatch) and CVE-2026-69192 (ip-address, via socks-proxy-agent → socks). npm 12.0.2 is the newest release, prereleases included, and still vendors 5.0.7 and 10.2.0; actionlint, shfmt, yq and hadolint are also at their latest upstream.
- Add `make scan NO_IGNORE=1`. It drops `--exit-code` along with the ignorefile, since findings are the expected output there and a failed target would bury them under a `make` error.
- Re-date all 16 suppressions to `2026-09-25`. `NO_IGNORE=1` confirmed every pre-existing entry still fires upstream, so they were extended together to land on one re-triage sweep.
- Bump Trivy to 0.73.0 in the scan recipe.

## Further Comments

CVE-2026-69152 bypasses the CVE-2026-14257 fix, moving the required brace-expansion version from 5.0.8 to 5.0.9, so both entries stay until npm bundles 5.0.9. Their reachability clauses are near-identical: npm could ship 5.0.8 and clear only 14257, and cross-referencing it from 69152 would then leave a pointer into a deleted entry.

#203 is retitled from "brace-expansion and x/text" to cover npm-vendored deps generally, since ip-address no longer fit, and its table now carries all four CVEs.

Verified with `make lint` and a Trivy 0.73.0 scan exiting 0 against the updated ignorefile. That scan used the existing `ci-tools:local` build rather than a fresh `make build`; its tool set matches `versions.lock`, and the publish workflow re-scans regardless.

The monitor alert goes quiet only after the next release — it scans the published image, not main.
