### PR TITLE
Consolidate Trivy scan policy into trivy.yaml and pin the scanner

### DIFF
--- a/.github/workflows/cve-monitor.yml
+++ b/.github/workflows/cve-monitor.yml
@@ -52,10 +52,12 @@ jobs:
 
     steps:
       - name: Checkout
-        # Sparse checkout: per-image .trivyignore.yaml and the issue body template.
+        # Sparse checkout: shared scan policy, per-image .trivyignore.yaml, and
+        # the issue body template.
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: |
+            trivy.yaml
             images/${{ matrix.image }}/.trivyignore.yaml
             docs/cve-monitor-issue.md
           sparse-checkout-cone-mode: false
@@ -63,15 +65,17 @@ jobs:
       - name: Scan published image for vulnerabilities
         id: trivy
         continue-on-error: true
-        # Same policy as publish: CRITICAL+HIGH, ignore-unfixed
+        # Policy comes from trivy.yaml, same as publish. Do not add
+        # severity/exit-code/ignore-unfixed inputs here — the action turns any
+        # input it receives into a TRIVY_* env var, which overrides the config
+        # file. The config's exit-code 1 is what the next step traps on.
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         with:
           image-ref: 'ghcr.io/knight-owl-dev/${{ matrix.image }}:latest'
-          exit-code: '1'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
+          trivy-config: trivy.yaml
           trivyignores: images/${{ matrix.image }}/.trivyignore.yaml
-          format: 'table'
+          # Keep in sync with the Makefile and publish.yml (see trivy.yaml).
+          version: v0.73.0
 
       - name: Open issue on findings
         if: steps.trivy.outcome == 'failure'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,14 +85,17 @@ jobs:
         # Scans the single-platform :verify image (amd64 on GitHub-hosted runners).
         # arm64 is not scanned separately — CVEs are tracked by source package, so
         # the amd64 scan covers the same package set for both architectures.
+        #
+        # Policy comes from trivy.yaml. Do not add severity/exit-code/
+        # ignore-unfixed inputs here — the action turns any input it receives
+        # into a TRIVY_* env var, which overrides the config file.
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         with:
           image-ref: ${{ matrix.image }}:verify
-          exit-code: '1'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true # skip upstream CVEs with no available patch
+          trivy-config: trivy.yaml
           trivyignores: images/${{ matrix.image }}/.trivyignore.yaml
-          format: 'table'
+          # Keep in sync with the Makefile and cve-monitor.yml (see trivy.yaml).
+          version: v0.73.0
 
       - name: Log in to GHCR
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/Makefile
+++ b/Makefile
@@ -53,25 +53,29 @@ verify:
 		-v "$(CURDIR)/images/$(IMAGE)/versions.lock:/versions.lock:ro" \
 		$(IMAGE_TAG) /scripts/$(IMAGE)/verify.sh
 
-# Scan image for vulnerabilities. NO_IGNORE=1 drops the suppression file to
-# report what .trivyignore.yaml hides, and drops --exit-code with it so the
-# report doesn't fail the build.
-ifndef NO_IGNORE
-TRIVY_IGNORE_MOUNT := -v "$(CURDIR)/images/$(IMAGE)/.trivyignore.yaml:/.trivyignore.yaml:ro"
-TRIVY_IGNORE_FLAG := --ignorefile /.trivyignore.yaml
-TRIVY_EXIT_CODE := --exit-code 1
+# Scan image for vulnerabilities. Policy lives in trivy.yaml; only the
+# per-image suppression file is passed here. NO_IGNORE=1 reports what
+# .trivyignore.yaml hides, overriding trivy.yaml's exit code so the report
+# doesn't fail the build.
+ifdef NO_IGNORE
+TRIVY_FLAGS := --ignorefile /dev/null --exit-code 0
+else
+TRIVY_FLAGS := --ignorefile images/$(IMAGE)/.trivyignore.yaml
 endif
+
+# Keep in sync with the trivy-action `version:` in publish.yml and
+# cve-monitor.yml (see trivy.yaml).
+TRIVY_IMAGE := aquasec/trivy:0.73.0
 
 scan: build
 	@echo "Scanning $(IMAGE_TAG) for vulnerabilities$(if $(NO_IGNORE), (suppressions disabled),)..."
 	@docker run --rm $(DOCKER_TTY) \
 		-v /var/run/docker.sock:/var/run/docker.sock \
-		$(TRIVY_IGNORE_MOUNT) \
-		aquasec/trivy:0.73.0 image \
-		$(TRIVY_IGNORE_FLAG) \
-		--severity CRITICAL,HIGH \
-		--ignore-unfixed \
-		$(TRIVY_EXIT_CODE) \
+		-v "$(CURDIR):/repo:ro" \
+		-w /repo \
+		$(TRIVY_IMAGE) image \
+		--config trivy.yaml \
+		$(TRIVY_FLAGS) \
 		$(IMAGE_TAG)
 
 # Run all linters. SKIP='lint-a lint-b' drops targets from the run — bootstraps

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,9 @@ lint-actions:
 	@echo "Validating GitHub Actions pins..." \
 		&& $(VALIDATE_ACTION_PINS) .github/workflows/*.yml .github/actions/*/action.yml \
 		&& echo "OK"
+	@echo "Validating Trivy version pins..." \
+		&& scripts/lib/validate-trivy-pins.sh \
+		&& echo "OK"
 
 # Lint Markdown files
 lint-md:

--- a/docs/how-to/add-image.md
+++ b/docs/how-to/add-image.md
@@ -61,9 +61,11 @@ both are auto-discovered:
 ### Vulnerability scanning
 
 `publish.yml` (and the scheduled `cve-monitor.yml`) scan the built image with
-Trivy for fixed `CRITICAL`/`HIGH` CVEs. **Always add
+Trivy for fixed `CRITICAL`/`HIGH` CVEs. Scan policy is shared across images by
+the repo-root `trivy.yaml`, so a new image needs no policy wiring — only its own
+suppression file. **Always add
 `images/<name>/.trivyignore.yaml`, even with nothing to suppress** — `make scan`
-bind-mounts it and passes `--ignorefile`, and both workflows pass `trivyignores:`
+passes `--ignorefile` and both workflows pass `trivyignores:`
 unconditionally, so a missing file breaks the scan. Seed it with the template
 below; an empty `vulnerabilities:` block is the correct "nothing suppressed"
 state. Add an entry only when you need to suppress a specific CVE — each entry
@@ -93,8 +95,10 @@ Copy this to the new `.trivyignore.yaml` (replace `<name>`):
 # scan, forcing a re-triage: bump the offending tool if a patched upstream
 # release shipped, or extend the date with a fresh justification.
 #
-# Trivy does NOT auto-detect this file — every invocation passes it explicitly
-# (Makefile `--ignorefile`, the trivy-action `trivyignores:` input). See
+# Suppressions only — the rest of the scan policy is shared across images in
+# the repo-root trivy.yaml. Trivy does NOT auto-detect this file: every
+# invocation names it explicitly (Makefile `--ignorefile`, the trivy-action
+# `trivyignores:` input), so a missing file fails the scan. See
 # docs/how-to/publish-image.md for the add/extend/remove workflow.
 #
 # Suppression entry example:

--- a/docs/how-to/publish-image.md
+++ b/docs/how-to/publish-image.md
@@ -153,7 +153,8 @@ make sync
 Each published image is protected by three mechanisms:
 
 - **CVE scanning** — Trivy scans the verified image for CRITICAL and HIGH
-  severity vulnerabilities before pushing. Unfixed CVEs are ignored.
+  severity vulnerabilities before pushing. Unfixed CVEs are ignored. Policy
+  lives in the repo-root `trivy.yaml`.
 - **SBOM attestation** — a Software Bill of Materials is generated during
   the multi-platform build and attached to the image in GHCR.
 - **Image signing** — cosign signs the pushed digest using keyless Sigstore
@@ -194,9 +195,10 @@ hasn't shipped a rebuild), suppress the CVE temporarily instead — see below.
 Suppressions live in `images/<image>/.trivyignore.yaml` in Trivy's structured
 format. Every entry carries a `statement` (the justification) and an
 `expired_at` date, so a suppression re-surfaces for re-triage instead of
-silencing the CVE forever. Trivy does **not** auto-detect this file — it is
-referenced explicitly by the Makefile (`--ignorefile`) and the trivy-action
-(`trivyignores:`), so no extra wiring is needed when you edit it.
+silencing the CVE forever. It holds suppressions only; the rest of the scan
+policy lives in the repo-root `trivy.yaml`. Trivy does **not** auto-detect
+this file — it is named explicitly by the Makefile (`--ignorefile`) and the
+trivy-action (`trivyignores:`), so no extra wiring is needed when you edit it.
 
 **Add an entry** when a fixable CVE has no patched upstream release yet:
 

--- a/docs/how-to/recipes/non-distributable-image.md
+++ b/docs/how-to/recipes/non-distributable-image.md
@@ -136,8 +136,8 @@ Create `images/docs/.trivyignore.yaml` with the template header and an empty
 `vulnerabilities:` key (copy the block from
 [Add an Image](../add-image.md#vulnerability-scanning)).
 
-> **Gotcha — it's effectively required, not optional.** `make scan` bind-mounts
-> this file and passes `--ignorefile`, and `publish.yml` / `cve-monitor.yml`
+> **Gotcha — it's effectively required, not optional.** `make scan` names this
+> file via `--ignorefile`, and `publish.yml` / `cve-monitor.yml`
 > pass `trivyignores:` unconditionally. A missing file breaks the scan, even
 > when you have nothing to suppress. An empty `vulnerabilities:` block is the
 > correct "no suppressions" state.
@@ -169,7 +169,7 @@ make resolve IMAGE=docs          # GENERATES images/docs/versions.lock
 make lint-lockfile IMAGE=docs    # lockfile keys == Dockerfile bare ARGs
 make build IMAGE=docs            # builds docs:local (multi-arch)
 make verify IMAGE=docs           # runs scripts/docs/verify.sh in-container
-make scan IMAGE=docs             # Trivy CRITICAL/HIGH, ignore-unfixed
+make scan IMAGE=docs             # Trivy, policy from trivy.yaml
 # make sync IMAGE=docs           # = resolve + build + verify in one
 ```
 

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -121,7 +121,8 @@ CRITICAL and HIGH severity vulnerabilities before any registry interaction.
 Scan policy lives in the repo-root `trivy.yaml`, read by `make scan`, the
 publish workflow, and the CVE monitor, so local and CI scans cannot diverge.
 Only the per-image `.trivyignore.yaml` is chosen at the call site. The scanner
-version is pinned at each of those call sites; `trivy.yaml` lists them.
+version is pinned at each of those call sites — `trivy.yaml` lists them, and
+`make lint-actions` fails if they drift.
 
 **Policy: `ignore-unfixed: true`** — CVEs with no available upstream patch are
 excluded from the scan results. This is a deliberate trade-off: blocking releases

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -118,6 +118,11 @@ they reach consumers:
 The publish workflow scans the single-platform `:verify` image for
 CRITICAL and HIGH severity vulnerabilities before any registry interaction.
 
+Scan policy lives in the repo-root `trivy.yaml`, read by `make scan`, the
+publish workflow, and the CVE monitor, so local and CI scans cannot diverge.
+Only the per-image `.trivyignore.yaml` is chosen at the call site. The scanner
+version is pinned at each of those call sites; `trivy.yaml` lists them.
+
 **Policy: `ignore-unfixed: true`** — CVEs with no available upstream patch are
 excluded from the scan results. This is a deliberate trade-off: blocking releases
 on vulnerabilities that cannot be remediated provides no actionable benefit and
@@ -138,19 +143,19 @@ published images. The `cve-monitor.yml` workflow closes this gap by scanning
 each published image on a schedule (Monday and Thursday at 08:00 UTC) and can
 also be triggered manually from the Actions tab.
 
-The scan uses the same Trivy policy as the publish workflow: CRITICAL and HIGH
-severity, `ignore-unfixed: true`, with the per-image `.trivyignore.yaml`. A
-clean scan produces a silent green run. If fixable vulnerabilities are found,
-the workflow opens a GitHub issue labeled `cve-monitor` and `security` with the
-full scan results.
+The scan reads the same `trivy.yaml` as the publish workflow, with the
+per-image `.trivyignore.yaml`. A clean scan produces a silent green run. If
+fixable vulnerabilities are found, the workflow opens a GitHub issue labeled
+`cve-monitor` and `security` with the full scan results.
 
 **Suppressions expire.** Each entry in `.trivyignore.yaml` carries both a
 `statement` (the justification) and an `expired_at` date. A suppression is a
 promise to revisit, not a permanent silence: once the date passes the entry
 stops suppressing and the CVE re-surfaces in the next scan, turning the CVE
 monitor into a forcing function for re-triage. Trivy does **not** auto-detect
-the `.yaml` file — every invocation references it explicitly (the Makefile
-`--ignorefile`, the trivy-action `trivyignores:` input). See
+the `.yaml` file — every invocation names it explicitly (the Makefile
+`--ignorefile`, the trivy-action `trivyignores:` input), so a missing file
+fails the scan. See
 [publish-image.md](how-to/publish-image.md#vulnerability-scan-failure-runbook)
 for the add/extend/remove workflow.
 

--- a/images/ci-tools/.trivyignore.yaml
+++ b/images/ci-tools/.trivyignore.yaml
@@ -5,8 +5,10 @@
 # scan, forcing a re-triage: bump the offending tool if a patched upstream
 # release shipped, or extend the date with a fresh justification.
 #
-# Trivy does NOT auto-detect this file — every invocation passes it explicitly
-# (Makefile `--ignorefile`, the trivy-action `trivyignores:` input). See
+# Suppressions only — the rest of the scan policy is shared across images in
+# the repo-root trivy.yaml. Trivy does NOT auto-detect this file: every
+# invocation names it explicitly (Makefile `--ignorefile`, the trivy-action
+# `trivyignores:` input), so a missing file fails the scan. See
 # docs/how-to/publish-image.md for the add/extend/remove workflow.
 #
 # Suppression entry example:

--- a/images/docs/.trivyignore.yaml
+++ b/images/docs/.trivyignore.yaml
@@ -5,8 +5,10 @@
 # scan, forcing a re-triage: bump the offending tool if a patched upstream
 # release shipped, or extend the date with a fresh justification.
 #
-# Trivy does NOT auto-detect this file — every invocation passes it explicitly
-# (Makefile `--ignorefile`, the trivy-action `trivyignores:` input). See
+# Suppressions only — the rest of the scan policy is shared across images in
+# the repo-root trivy.yaml. Trivy does NOT auto-detect this file: every
+# invocation names it explicitly (Makefile `--ignorefile`, the trivy-action
+# `trivyignores:` input), so a missing file fails the scan. See
 # docs/how-to/publish-image.md for the add/extend/remove workflow.
 #
 # Suppression entry example:

--- a/scripts/lib/validate-trivy-pins.sh
+++ b/scripts/lib/validate-trivy-pins.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# validate-trivy-pins.sh — Validate that the Trivy scanner version matches
+# across every call site.
+#
+# trivy.yaml lists the call sites and the tag shape each one takes. Two failure
+# modes justify the check: a bare GitHub tag 404s in trivy's install.sh, and an
+# absent workflow pin leaves trivy-action installing its own bundled version.
+#
+# Usage:
+#   scripts/lib/validate-trivy-pins.sh
+#
+# Exit codes:
+#   0 - Every pin present, correctly prefixed, and equal
+#   1 - A pin missing, wrongly prefixed, or drifted
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+makefile="${REPO_ROOT}/Makefile"
+workflows=(
+  "${REPO_ROOT}/.github/workflows/publish.yml"
+  "${REPO_ROOT}/.github/workflows/cve-monitor.yml"
+)
+
+errors=0
+fail() {
+  echo "$1" >&2
+  errors=1
+}
+
+# Docker tag from the Makefile — bare.
+matches="$(sed -n 's|^.*aquasec/trivy:\([^ "]*\).*$|\1|p' "${makefile}")"
+make_pin="${matches%%$'\n'*}"
+
+if [[ -z "${make_pin}" ]]; then
+  fail "Makefile: no aquasec/trivy:<version> pin found"
+elif [[ "${make_pin}" == v* ]]; then
+  fail "Makefile: Docker tag must be bare, got 'aquasec/trivy:${make_pin}'"
+fi
+
+expected="${make_pin#v}"
+
+# GitHub release tag from each trivy-action step — v-prefixed.
+for workflow in "${workflows[@]}"; do
+  name="$(basename "${workflow}")"
+
+  if [[ ! -f "${workflow}" ]]; then
+    fail "${name}: workflow not found"
+    continue
+  fi
+
+  pins="$(
+    yq -r '.jobs[].steps[]?
+      | select(.uses // "" | test("^aquasecurity/trivy-action@"))
+      | .with.version // "MISSING"' "${workflow}"
+  )"
+
+  if [[ -z "${pins}" ]]; then
+    fail "${name}: no aquasecurity/trivy-action step found"
+    continue
+  fi
+
+  while IFS= read -r pin; do
+    if [[ "${pin}" == "MISSING" ]]; then
+      fail "${name}: trivy-action step has no 'version:' — it would install the action's own default"
+    elif [[ "${pin}" != v* ]]; then
+      fail "${name}: release tag must be v-prefixed, got 'version: ${pin}'"
+    elif [[ "${pin#v}" != "${expected}" ]]; then
+      fail "${name}: pinned to '${pin}', Makefile pins '${expected}'"
+    fi
+  done <<< "${pins}"
+done
+
+[[ "${errors}" -eq 0 ]] || exit 1

--- a/tests/bats/scripts/lib/validate-trivy-pins.bats
+++ b/tests/bats/scripts/lib/validate-trivy-pins.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+#
+# Tests for scripts/lib/validate-trivy-pins.sh — the gate that keeps the Trivy
+# scanner version equal across the Makefile and both scanning workflows. Each
+# test builds a minimal fake repo under BATS_TEST_TMPDIR holding a Makefile and
+# the two workflows, then runs the script against it.
+#
+# REPO_ROOT inside the script is derived from its own path, so we symlink the
+# real scripts/lib into the fake repo.
+
+load ../../helpers/common
+
+setup() {
+  common_setup
+  FAKE_REPO="${BATS_TEST_TMPDIR}/repo"
+  mkdir -p "${FAKE_REPO}/scripts" "${FAKE_REPO}/.github/workflows"
+  ln -s "${REPO_ROOT}/scripts/lib" "${FAKE_REPO}/scripts/lib"
+  SCRIPT="${FAKE_REPO}/scripts/lib/validate-trivy-pins.sh"
+  export SCRIPT FAKE_REPO
+}
+
+_make_makefile() { printf 'TRIVY_IMAGE := aquasec/trivy:%s\n' "$1" > "${FAKE_REPO}/Makefile"; }
+
+# _make_workflow <name> [version] — an empty version omits the `version:` input.
+_make_workflow() {
+  local name="$1" version="${2-}"
+  {
+    echo "jobs:"
+    echo "  scan:"
+    echo "    steps:"
+    echo "      - uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25"
+    echo "        with:"
+    echo "          image-ref: example:latest"
+    if [[ -n "${version}" ]]; then
+      echo "          version: ${version}"
+    fi
+  } > "${FAKE_REPO}/.github/workflows/${name}.yml"
+}
+
+# Both workflows pinned identically unless a test overrides one.
+_make_workflows() {
+  _make_workflow publish "$1"
+  _make_workflow cve-monitor "$1"
+}
+
+# ── happy path ───────────────────────────────────────────────────────
+
+@test "exits 0 when the Makefile and both workflows pin the same version" {
+  _make_makefile "0.73.0"
+  _make_workflows "v0.73.0"
+  run "${SCRIPT}"
+  assert_success
+  assert_output ""
+}
+
+# ── drift ────────────────────────────────────────────────────────────
+
+@test "exits 1 and names both versions when a workflow drifts from the Makefile" {
+  _make_makefile "0.73.0"
+  _make_workflow publish "v0.73.0"
+  _make_workflow cve-monitor "v0.70.0"
+  run "${SCRIPT}"
+  assert_failure 1
+  assert_output --partial "cve-monitor.yml: pinned to 'v0.70.0', Makefile pins '0.73.0'"
+}
+
+@test "reports every drifted workflow, not just the first" {
+  _make_makefile "0.73.0"
+  _make_workflows "v0.70.0"
+  run "${SCRIPT}"
+  assert_failure 1
+  assert_output --partial "publish.yml: pinned to 'v0.70.0'"
+  assert_output --partial "cve-monitor.yml: pinned to 'v0.70.0'"
+}
+
+# ── prefix rules ─────────────────────────────────────────────────────
+
+@test "exits 1 when a workflow pin lacks the v prefix" {
+  _make_makefile "0.73.0"
+  _make_workflow publish "0.73.0"
+  _make_workflow cve-monitor "v0.73.0"
+  run "${SCRIPT}"
+  assert_failure 1
+  assert_output --partial "publish.yml: release tag must be v-prefixed"
+}
+
+@test "exits 1 when the Makefile Docker tag carries a v prefix" {
+  _make_makefile "v0.73.0"
+  _make_workflows "v0.73.0"
+  run "${SCRIPT}"
+  assert_failure 1
+  assert_output --partial "Makefile: Docker tag must be bare"
+}
+
+# ── missing pins ─────────────────────────────────────────────────────
+
+@test "exits 1 when a trivy-action step omits version, which would use the action default" {
+  _make_makefile "0.73.0"
+  _make_workflow publish ""
+  _make_workflow cve-monitor "v0.73.0"
+  run "${SCRIPT}"
+  assert_failure 1
+  assert_output --partial "publish.yml: trivy-action step has no 'version:'"
+}
+
+@test "exits 1 when a workflow has no trivy-action step at all" {
+  _make_makefile "0.73.0"
+  _make_workflow publish "v0.73.0"
+  printf 'jobs:\n  scan:\n    steps:\n      - run: echo hi\n' \
+    > "${FAKE_REPO}/.github/workflows/cve-monitor.yml"
+  run "${SCRIPT}"
+  assert_failure 1
+  assert_output --partial "cve-monitor.yml: no aquasecurity/trivy-action step found"
+}
+
+@test "exits 1 when the Makefile has no trivy image pin" {
+  printf 'all:\n\t@echo hi\n' > "${FAKE_REPO}/Makefile"
+  _make_workflows "v0.73.0"
+  run "${SCRIPT}"
+  assert_failure 1
+  assert_output --partial "Makefile: no aquasec/trivy:<version> pin found"
+}
+
+@test "exits 1 when a workflow file is missing" {
+  _make_makefile "0.73.0"
+  _make_workflow publish "v0.73.0"
+  run "${SCRIPT}"
+  assert_failure 1
+  assert_output --partial "cve-monitor.yml: workflow not found"
+}

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -8,7 +8,7 @@
 # var for any input it receives, and env beats this file.
 #
 # The scanner version is pinned per call site — a config file cannot select its
-# own binary. Bump together:
+# own binary. Bump together; `make lint-actions` fails if they drift:
 #   Makefile          aquasec/trivy:<ver>       (Docker tag, bare)
 #   publish.yml       trivy-action `version:`   (GitHub tag, v-prefixed)
 #   cve-monitor.yml   trivy-action `version:`

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,26 @@
+# Shared Trivy scan policy for every image.
+#
+# Read by `make scan` (--config), the publish workflow and the CVE monitor
+# (trivy-action `trivy-config:`). Suppressions are not set here — they vary by
+# image, so each call site passes its own --ignorefile / `trivyignores:`.
+#
+# Callers must not repeat these settings: trivy-action exports a TRIVY_* env
+# var for any input it receives, and env beats this file.
+#
+# The scanner version is pinned per call site — a config file cannot select its
+# own binary. Bump together:
+#   Makefile          aquasec/trivy:<ver>       (Docker tag, bare)
+#   publish.yml       trivy-action `version:`   (GitHub tag, v-prefixed)
+#   cve-monitor.yml   trivy-action `version:`
+
+severity:
+  - CRITICAL
+  - HIGH
+
+# `make scan NO_IGNORE=1` overrides this with --exit-code 0.
+exit-code: 1
+
+vulnerability:
+  # Must stay nested: a top-level `ignore-unfixed` parses fine and does nothing.
+  # Rationale in docs/supply-chain-security.md.
+  ignore-unfixed: true


### PR DESCRIPTION
## Summary

Scan policy had one owner per call site instead of one owner. Severity, exit code, and ignore-unfixed were repeated in the Makefile `scan` target and both trivy-action steps, so a policy change meant three edits and a divergence stayed silent. The scanner version had already diverged: the Makefile pinned 0.73.0 while both workflows took the action's v0.70.0 default, so a clean local scan said nothing about what CI would find. Policy now lives in a repo-root `trivy.yaml` that all three read, and the version is pinned everywhere with a lint gate that fails on drift.

## Related Issues

Fixes #218

## Changes

- `trivy.yaml` owns severity, exit code, and `ignore-unfixed`; the Makefile and both workflows pass only an image ref and the per-image ignore file, which is the one setting that genuinely varies
- Scanner pinned at all three call sites, plus a `make lint-actions` gate (`validate-trivy-pins.sh` + bats coverage) that fails on drift, a missing workflow pin, or a wrong tag prefix
- `make scan` mounts the repo root read-only and passes relative paths, so its ignore-file path reads the same as the workflows' `trivyignores:` input
- Docs and both `.trivyignore.yaml` headers repointed at `trivy.yaml` as the policy owner, with the suppression files scoped to suppressions

## Further Comments

Verified against the pinned 0.73.0 image rather than assumed: the config honors `severity`, `exit-code`, and `vulnerability.ignore-unfixed`; CLI flags override it; and a named-but-absent ignore file is FATAL. One footgun found and commented in the file — a **top-level** `ignore-unfixed` parses without error and silently does nothing, so it must stay nested under `vulnerability`.

The issue proposed accepting the three-place version duplication with cross-referencing comments, on the grounds that a `.trivy-version` mechanism is too much machinery for one scalar. This adds the drift check instead: the version stays visible at each call site, and a bad edit fails CI rather than waiting to be noticed. The check also encodes an asymmetry that is easy to get wrong — the Makefile names a Docker tag (bare) while the workflows name a GitHub release tag (v-prefixed, since a bare value 404s in trivy's `install.sh`).

The redundant `format: 'table'` inputs are gone, matching the action's own default. That deletion is behavior-neutral but unexercised by PR CI, since the scan steps only run on a release tag.

Checked locally: `make lint` green, 226 bats tests passing, and `make scan` clean on both `ci-tools` and `docs` with `NO_IGNORE=1` correctly surfacing the 17 suppressed CVEs at HIGH/CRITICAL only.
