### PR TITLE
Fail the Trivy scan step when the scan policy is missing

### DIFF
--- a/.github/workflows/cve-monitor.yml
+++ b/.github/workflows/cve-monitor.yml
@@ -62,6 +62,18 @@ jobs:
             docs/cve-monitor-issue.md
           sparse-checkout-cone-mode: false
 
+      - name: Assert scan policy is present
+        # Nothing validates trivy-config: the action only exports it as
+        # TRIVY_CONFIG (see trivy.yaml) and Trivy treats an unreadable config as
+        # absent — every severity, exit 0. Drift in the sparse-checkout list
+        # above would scan clean while enforcing nothing. trivyignores needs no
+        # such check; the action's entrypoint fails closed on a missing path.
+        run: |
+          if [[ ! -f trivy.yaml ]]; then
+            echo "ERROR: trivy.yaml missing — the scan would pass without enforcing policy" >&2
+            exit 1
+          fi
+
       - name: Scan published image for vulnerabilities
         id: trivy
         continue-on-error: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,6 +81,15 @@ jobs:
       - name: Verify tools
         run: make verify IMAGE=${{ matrix.image }} IMAGE_TAG=${{ matrix.image }}:verify
 
+      - name: Assert scan policy is present
+        # trivy-config fails open — a missing trivy.yaml scans with defaults and
+        # exits 0, un-gating publish without a trace. Rationale in cve-monitor.yml.
+        run: |
+          if [[ ! -f trivy.yaml ]]; then
+            echo "ERROR: trivy.yaml missing — the scan would pass without enforcing policy" >&2
+            exit 1
+          fi
+
       - name: Scan for vulnerabilities
         # Scans the single-platform :verify image (amd64 on GitHub-hosted runners).
         # arm64 is not scanned separately — CVEs are tracked by source package, so


### PR DESCRIPTION
## Summary

A green Trivy step now means policy was enforced. `trivy-config:` fails open — the action exports the path as `TRIVY_CONFIG`, validates nothing, and Trivy ignores a config it cannot read — so a missing `trivy.yaml` scanned with built-in defaults (every severity, `exit-code` 0) and passed. Publishing could ship an unscanned image and the CVE monitor could report all-clear indefinitely, both without a trace in the logs.

## Related Issues

Fixes #220

## Changes

- Fail before scanning if `trivy.yaml` is absent, in both `publish.yml` and `cve-monitor.yml`.

## Further Comments

Three decisions a reviewer will want to challenge:

**Why keep trivy-action, given it is the thing that fails open?** `setup-trivy` plus a direct `trivy image --config trivy.yaml` fails closed at the tool and would need no guard, but it gives up the action's cached vulnerability DB — a ~100 MB download per matrix job. The guard is cheaper.

**Why duplicate the check instead of sharing a script?** `cve-monitor` sparse-checks out only `trivy.yaml`, the per-image `.trivyignore.yaml`, and the issue template. Sharing a script adds a fourth hand-maintained path to the very list the guard protects.

**Why isn't `trivyignores:` guarded too?** The action's `entrypoint.sh` already fails closed on a missing ignore path. The two inputs behave differently; only the config one is silent.

Verified at `aquasec/trivy:0.73.0` + trivy-action 0.36.0: `trivy --config missing.yaml` exits 1 with `FATAL config file loading error`, while `TRIVY_CONFIG=missing.yaml trivy …` scans with defaults and exits 0. The action only ever sets the env var.
