### PR TITLE
Lock the Trivy scan policy values in a test

### DIFF
--- a/.github/workflows/cve-monitor.yml
+++ b/.github/workflows/cve-monitor.yml
@@ -64,13 +64,14 @@ jobs:
 
       - name: Assert scan policy is present
         # Nothing validates trivy-config: the action only exports it as
-        # TRIVY_CONFIG (see trivy.yaml) and Trivy treats an unreadable config as
-        # absent — every severity, exit 0. Drift in the sparse-checkout list
-        # above would scan clean while enforcing nothing. trivyignores needs no
-        # such check; the action's entrypoint fails closed on a missing path.
+        # TRIVY_CONFIG (see trivy.yaml), and Trivy ignores one it cannot read.
+        # Drift in the sparse-checkout list above would scan every severity and
+        # exit 0 — clean, enforcing nothing. trivyignores needs no such check:
+        # the action's entrypoint fails closed on a missing path.
+        # tests/bats/trivy-policy.bats covers the policy's contents.
         run: |
-          if [[ ! -f trivy.yaml ]]; then
-            echo "ERROR: trivy.yaml missing — the scan would pass without enforcing policy" >&2
+          if [[ ! -r trivy.yaml ]]; then
+            echo "ERROR: trivy.yaml unreadable — the scan would pass without enforcing policy" >&2
             exit 1
           fi
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,11 +82,11 @@ jobs:
         run: make verify IMAGE=${{ matrix.image }} IMAGE_TAG=${{ matrix.image }}:verify
 
       - name: Assert scan policy is present
-        # trivy-config fails open — a missing trivy.yaml scans with defaults and
-        # exits 0, un-gating publish without a trace. Rationale in cve-monitor.yml.
+        # trivy-config fails open: a trivy.yaml Trivy cannot read scans with
+        # defaults and exits 0, un-gating publish. Rationale in cve-monitor.yml.
         run: |
-          if [[ ! -f trivy.yaml ]]; then
-            echo "ERROR: trivy.yaml missing — the scan would pass without enforcing policy" >&2
+          if [[ ! -r trivy.yaml ]]; then
+            echo "ERROR: trivy.yaml unreadable — the scan would pass without enforcing policy" >&2
             exit 1
           fi
 

--- a/tests/bats/trivy-policy.bats
+++ b/tests/bats/trivy-policy.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+# shellcheck shell=bash
+#
+# Trivy substitutes built-in defaults for whatever trivy.yaml omits and reports
+# no error, so a gutted policy scans clean.
+
+load helpers/common
+
+setup() {
+  common_setup
+}
+
+@test "trivy.yaml declares the policy values it owns" {
+  # `exit-code: 0` keeps the key and drops the gate, so the assertions compare
+  # values.
+  run yq -r '[
+      .["exit-code"],
+      (.severity | sort | join("+")),
+      .vulnerability["ignore-unfixed"]
+    ] | .[]' "${REPO_ROOT}/trivy.yaml"
+  assert_success
+  assert_line --index 0 '1'
+  assert_line --index 1 'CRITICAL+HIGH'
+  assert_line --index 2 'true'
+}


### PR DESCRIPTION
## Summary

An empty or gutted `trivy.yaml` passed `make lint` and would scan clean while enforcing nothing — Trivy substitutes built-in defaults for whatever the config omits and reports no error. The policy values are now asserted in bats, and the workflow steps check that the config is readable rather than merely present.

## Related Issues

Fixes #222

## Changes

- Policy-content assertions live in bats rather than in the workflow step or a lint script: bats runs inside ci-tools, so yq is available, whereas the workflow steps run on a bare runner and would make a security gate depend on the runner image's yq.
- The two checks answer different questions and neither subsumes the other — bats validates the repo copy at PR time, the workflow step validates that the file reached the job. `tests/bats/trivy-policy.bats` is the first test under `tests/bats/` targeting a repo-root config rather than a script or image binary.

## Further Comments

The test shape follows the equivalent keystone suite. Confirmed it bites before relying on it: a blank `trivy.yaml` fails on yq's non-zero exit, and `exit-code: 0` fails on the value rather than slipping past a key-presence check.

Sparse-checkout drift in `cve-monitor.yml` is still caught only at job time. Moving it to PR time would take a repo-level assertion that `trivy.yaml` appears in that workflow's sparse-checkout list — out of scope here, noted on the issue.
