### PR TITLE
Validate every image's lockfile on every lint run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,15 +123,23 @@ LINT_RUNNER ?= docker run --rm $(DOCKER_TTY) \
 	-v "$(CURDIR):/work" -w /work $(TOOLS_IMAGE) make
 LINT_IMAGE_DEP := $(call image_dep,$(LINT_RUNNER))
 
+# The empty default rides through to the inner make, so a bare `make lint`
+# sweeps every image while `make lint IMAGE=docs` still scopes: a command-line
+# assignment beats the target-specific one at both boundaries.
+lint: IMAGE :=
 lint: $(LINT_IMAGE_DEP)
 	@$(LINT_RUNNER) IMAGE=$(IMAGE) $(filter-out $(SKIP),$(LINT_TARGETS))
 
 # Fix all auto-fixable lint issues. Containerized alongside lint: a host
 # shfmt that formats differently would write what the image then rejects.
 lint-fix: $(LINT_IMAGE_DEP)
-	@$(LINT_RUNNER) IMAGE=$(IMAGE) lint-sh-fmt-fix lint-md-fix
+	@$(LINT_RUNNER) lint-sh-fmt-fix lint-md-fix
 
-# Validate lockfile keys match Dockerfile ARGs
+# Validate lockfile keys match Dockerfile ARGs and compose build args. The
+# target-specific empty default overrides the global IMAGE=ci-tools, the same
+# way test-package does, so a bare `make lint` sweeps every image; a
+# command-line IMAGE=<name> still wins and scopes to one.
+lint-lockfile: IMAGE :=
 lint-lockfile:
 	@echo "Validating lockfile..." && scripts/lib/validate-lockfile.sh $(IMAGE) && echo "OK"
 

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,8 @@ TOOLS_IMAGE ?= ci-tools:local
 # (CI, already inside the image) get no dependency — there is no Docker there.
 image_dep = $(if $(filter docker,$(firstword $(1))),tools-image)
 
-# Depends on ci-tools, so it cannot be `build`: that honors IMAGE, which
-# selects what a target acts on. `lint IMAGE=docs` needs the docs lockfile
-# checked by the ci-tools toolchain, not the docs image built.
+# Builds $(TOOLS_IMAGE) specifically. `build` honors IMAGE and would build
+# whichever image the caller is acting on.
 tools-image:
 	@$(MAKE) --no-print-directory build IMAGE=ci-tools
 
@@ -112,20 +111,16 @@ LINT_TARGETS := lint-lockfile lint-docker lint-sh lint-sh-fmt lint-actions \
 	lint-md lint-spell lint-man
 
 # The lint targets invoke their tools bare, so the toolchain comes from
-# wherever make runs. Host tools drift from the image's (shfmt formats
-# differently across minor versions), so the aggregate targets re-enter
-# ci-tools and CI — already inside that image — overrides with
-# `LINT_RUNNER=make`.
-#
-# Always ci-tools, never $(IMAGE_TAG): that image is the lint toolchain,
-# while IMAGE selects which lockfile lint-lockfile validates.
+# wherever make runs, and host tools drift from the image's — shfmt formats
+# differently across minor versions. The aggregate targets therefore re-enter
+# the image. CI, already inside it, overrides with `LINT_RUNNER=make`.
 LINT_RUNNER ?= docker run --rm $(DOCKER_TTY) \
 	-v "$(CURDIR):/work" -w /work $(TOOLS_IMAGE) make
 LINT_IMAGE_DEP := $(call image_dep,$(LINT_RUNNER))
 
-# The empty default rides through to the inner make, so a bare `make lint`
-# sweeps every image while `make lint IMAGE=docs` still scopes: a command-line
-# assignment beats the target-specific one at both boundaries.
+# The empty default rides through to the inner make, so scoping survives the
+# container hop: a command-line assignment beats the target-specific one at
+# both boundaries.
 lint: IMAGE :=
 lint: $(LINT_IMAGE_DEP)
 	@$(LINT_RUNNER) IMAGE=$(IMAGE) $(filter-out $(SKIP),$(LINT_TARGETS))
@@ -135,10 +130,9 @@ lint: $(LINT_IMAGE_DEP)
 lint-fix: $(LINT_IMAGE_DEP)
 	@$(LINT_RUNNER) lint-sh-fmt-fix lint-md-fix
 
-# Validate lockfile keys match Dockerfile ARGs and compose build args. The
-# target-specific empty default overrides the global IMAGE=ci-tools, the same
-# way test-package does, so a bare `make lint` sweeps every image; a
-# command-line IMAGE=<name> still wins and scopes to one.
+# Validate lockfile keys against Dockerfile ARGs and compose build args.
+# Target-specific empty default, as in test-package: it beats the global
+# IMAGE=ci-tools so a bare run sweeps, and loses to a command-line IMAGE=<name>.
 lint-lockfile: IMAGE :=
 lint-lockfile:
 	@echo "Validating lockfile..." && scripts/lib/validate-lockfile.sh $(IMAGE) && echo "OK"

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,14 @@ IMAGE_TAG ?= $(IMAGE):local
 VALIDATE_ACTION_PINS := $(shell \
 	command -v validate-action-pins 2>/dev/null \
 	|| echo images/ci-tools/bin/validate-action-pins)
-# Pass `-t` to `docker run` when stdin is a terminal, so TTY-aware tools
-# (bats pretty output, etc.) see a real terminal inside the container.
+# Whether a human is watching. Probed once; both the container TTY and the
+# bats formatter key off it.
+IS_TTY := $(shell test -t 0 && echo 1)
+
+# Pass `-t` to `docker run` when stdin is a terminal, so TTY-aware tools see a
+# real terminal inside the container.
 # Override with `DOCKER_TTY=` (empty) or `DOCKER_TTY=-t` (force) as needed.
-DOCKER_TTY ?= $(shell test -t 0 && echo -t)
+DOCKER_TTY ?= $(if $(IS_TTY),-t)
 
 # ci-tools carries the lint and test toolchain, so recipes re-enter it
 # regardless of IMAGE — IMAGE selects what a target acts on, never where it
@@ -215,8 +219,14 @@ BATS_RUNNER ?= docker run --rm $(DOCKER_TTY) \
 	-v "$(CURDIR):/work" -w /work $(TOOLS_IMAGE) bats
 BATS_IMAGE_DEP := $(call image_dep,$(BATS_RUNNER))
 
+# bats defaults to TAP whatever it is attached to — its own --help claims
+# otherwise, and the terminal check it does run only decorates a formatter
+# already set to pretty. Ask for pretty when someone is watching, and leave CI
+# on TAP.
+BATS_FORMAT := $(if $(IS_TTY),--pretty)
+
 test-bats: $(BATS_IMAGE_DEP)
-	@$(BATS_RUNNER) -r tests/bats/
+	@$(BATS_RUNNER) $(BATS_FORMAT) -r tests/bats/
 
 # Remove local image
 clean:

--- a/images/ci-tools/Dockerfile
+++ b/images/ci-tools/Dockerfile
@@ -181,9 +181,8 @@ COPY --from=lua-builder /usr/local/bin/luacheck /usr/local/bin/luacheck
 COPY --from=lua-builder /usr/local/bin/busted /usr/local/bin/busted
 
 # ---------- bats-core ----------
-# bats and its helpers publish no release assets, so there is no tarball to
-# checksum. The tag selects the clone; the commit assert is the actual pin,
-# failing the build if a tag ever moves — before install.sh runs.
+# With no release assets to checksum, the commit assert is the pin: the tag
+# selects the clone, and a moved tag fails the build before install.sh runs.
 ARG BATS_VERSION
 ARG BATS_COMMIT
 RUN git clone --depth 1 --branch "${BATS_VERSION}" \

--- a/scripts/lib/images.sh
+++ b/scripts/lib/images.sh
@@ -70,6 +70,17 @@ distributable_images() {
   _images_with_file distributable
 }
 
+# Echo the names of images carrying a `Dockerfile`, one per line, in directory
+# order. This is the widest of the three sets: an image has a Dockerfile from
+# the moment it exists, before it earns a `version` stamp or a `distributable`
+# marker. Use it for checks that must cover an image from day one rather than
+# from its first release.
+#
+# Assumes the current working directory is the repo root.
+buildable_images() {
+  _images_with_file Dockerfile
+}
+
 # Echo the names of images carrying a `version` file, one per line, in
 # directory order. The version file is the release stamp every image acquires
 # on its first release; its presence (not its value) is what marks a directory

--- a/scripts/lib/validate-lockfile.sh
+++ b/scripts/lib/validate-lockfile.sh
@@ -11,9 +11,8 @@ set -euo pipefail
 # forwards reaches the build empty, and `npm install -g "pkg@"` installs
 # latest — a pin that silently resolves to whatever upstream ships.
 #
-# Every image is checked unless one is named. Scoping to a single image is the
-# exception: a sweep that quietly covered one image is the defect this guards
-# against, so the safe set is the default.
+# Every image is checked unless one is named, so omitting the argument widens
+# the check rather than narrowing it.
 #
 # Usage:
 #   scripts/lib/validate-lockfile.sh            # every image

--- a/scripts/lib/validate-lockfile.sh
+++ b/scripts/lib/validate-lockfile.sh
@@ -11,11 +11,13 @@ set -euo pipefail
 # forwards reaches the build empty, and `npm install -g "pkg@"` installs
 # latest — a pin that silently resolves to whatever upstream ships.
 #
-# Usage:
-#   scripts/lib/validate-lockfile.sh <image>
+# Every image is checked unless one is named. Scoping to a single image is the
+# exception: a sweep that quietly covered one image is the defect this guards
+# against, so the safe set is the default.
 #
-# Example:
-#   scripts/lib/validate-lockfile.sh ci-tools
+# Usage:
+#   scripts/lib/validate-lockfile.sh            # every image
+#   scripts/lib/validate-lockfile.sh <image>    # scope to one
 #
 # Exit codes:
 #   0 - Lockfile and Dockerfile ARGs match
@@ -26,77 +28,100 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 # shellcheck source=scripts/lib/resolve.sh
 source "${SCRIPT_DIR}/resolve.sh"
+# shellcheck source=scripts/lib/images.sh
+source "${SCRIPT_DIR}/images.sh"
 
-image="${1:-}"
-[[ -n "${image}" ]] || die "usage: validate-lockfile.sh <image>"
+validate_image() {
+  local image="${1}"
+  local dockerfile lockfile compose
+  dockerfile="${REPO_ROOT}/images/${image}/Dockerfile"
+  lockfile="${REPO_ROOT}/images/${image}/versions.lock"
+  compose="${REPO_ROOT}/images/${image}/compose.yaml"
 
-dockerfile="${REPO_ROOT}/images/${image}/Dockerfile"
-lockfile="${REPO_ROOT}/images/${image}/versions.lock"
-compose="${REPO_ROOT}/images/${image}/compose.yaml"
+  [[ -f "${dockerfile}" ]] || die "Dockerfile not found: ${dockerfile}"
+  [[ -f "${lockfile}" ]] || die "lockfile not found: ${lockfile}"
+  [[ -f "${compose}" ]] || die "compose file not found: ${compose}"
 
-[[ -f "${dockerfile}" ]] || die "Dockerfile not found: ${dockerfile}"
-[[ -f "${lockfile}" ]] || die "lockfile not found: ${lockfile}"
-[[ -f "${compose}" ]] || die "compose file not found: ${compose}"
+  local tmpdir
+  tmpdir="$(mktemp -d)"
 
-tmpdir="$(mktemp -d)"
-cleanup() { rm -rf "${tmpdir}"; }
-trap cleanup EXIT
+  # Bare ARG names from Dockerfile (no default value), excluding TARGETARCH.
+  sed -n 's/^ARG \([A-Z_][A-Z0-9_]*\)$/\1/p' "${dockerfile}" \
+    | sed '/^TARGETARCH$/d' \
+    | sort > "${tmpdir}/dockerfile"
 
-# Bare ARG names from Dockerfile (no default value), excluding TARGETARCH.
-sed -n 's/^ARG \([A-Z_][A-Z0-9_]*\)$/\1/p' "${dockerfile}" \
-  | sed '/^TARGETARCH$/d' \
-  | sort > "${tmpdir}/dockerfile"
+  # Key names from lockfile.
+  sed -n 's/^\([A-Z_][A-Z0-9_]*\)=.*/\1/p' "${lockfile}" \
+    | sort > "${tmpdir}/lockfile"
 
-# Key names from lockfile.
-sed -n 's/^\([A-Z_][A-Z0-9_]*\)=.*/\1/p' "${lockfile}" \
-  | sort > "${tmpdir}/lockfile"
+  # Build arg names from compose.yaml. The Dockerfile is not YAML, so it is
+  # pattern-matched above; compose.yaml is, so it is parsed — quoting and layout
+  # variations cannot slip an arg past the check.
+  yq -r '.services[].build.args // {} | keys | .[]' "${compose}" \
+    | sort > "${tmpdir}/compose"
 
-# Build arg names from compose.yaml. The Dockerfile is not YAML, so it is
-# pattern-matched above; compose.yaml is, so it is parsed — quoting and layout
-# variations cannot slip an arg past the check.
-yq -r '.services[].build.args // {} | keys | .[]' "${compose}" \
-  | sort > "${tmpdir}/compose"
+  local only_in_dockerfile only_in_lockfile not_forwarded crossed
+  only_in_dockerfile="$(comm -23 "${tmpdir}/dockerfile" "${tmpdir}/lockfile")"
+  only_in_lockfile="$(comm -13 "${tmpdir}/dockerfile" "${tmpdir}/lockfile")"
+  not_forwarded="$(comm -23 "${tmpdir}/dockerfile" "${tmpdir}/compose")"
 
-# Find mismatches in both directions.
-only_in_dockerfile="$(comm -23 "${tmpdir}/dockerfile" "${tmpdir}/lockfile")"
-only_in_lockfile="$(comm -13 "${tmpdir}/dockerfile" "${tmpdir}/lockfile")"
-not_forwarded="$(comm -23 "${tmpdir}/dockerfile" "${tmpdir}/compose")"
+  # Every arg must forward its identically-named variable. A crossed wire
+  # (`FOO: ${BAR}`) and a hardcoded literal both fail this.
+  #
+  # SC2016: the ${...} below is yq building the string to compare against,
+  # not a shell expansion — single quotes are required.
+  # shellcheck disable=SC2016
+  crossed="$(yq -r '.services[].build.args // {}
+    | to_entries[]
+    | select(.value != "${" + .key + "}")
+    | .key + ": " + (.value | tostring)' "${compose}")"
 
-# Every arg must forward its identically-named variable. A crossed wire
-# (`FOO: ${BAR}`) and a hardcoded literal both fail this.
-#
-# SC2016: the ${...} below is yq building the string to compare against,
-# not a shell expansion — single quotes are required.
-# shellcheck disable=SC2016
-crossed="$(yq -r '.services[].build.args // {}
-  | to_entries[]
-  | select(.value != "${" + .key + "}")
-  | .key + ": " + (.value | tostring)' "${compose}")"
+  rm -rf "${tmpdir}"
+
+  local errors=0
+
+  if [[ -n "${only_in_dockerfile}" ]]; then
+    echo "ARGs in Dockerfile missing from versions.lock:" >&2
+    echo "  ${only_in_dockerfile//$'\n'/$'\n'  }" >&2
+    errors=1
+  fi
+
+  if [[ -n "${only_in_lockfile}" ]]; then
+    echo "Keys in versions.lock missing from Dockerfile:" >&2
+    echo "  ${only_in_lockfile//$'\n'/$'\n'  }" >&2
+    errors=1
+  fi
+
+  if [[ -n "${not_forwarded}" ]]; then
+    echo "ARGs in Dockerfile not forwarded by compose.yaml (reach the build empty):" >&2
+    echo "  ${not_forwarded//$'\n'/$'\n'  }" >&2
+    errors=1
+  fi
+
+  if [[ -n "${crossed}" ]]; then
+    echo "compose.yaml build args forwarding a differently-named variable:" >&2
+    echo "  ${crossed//$'\n'/$'\n'  }" >&2
+    errors=1
+  fi
+
+  return "${errors}"
+}
+
+cd "${REPO_ROOT}"
+
+images=()
+if [[ -n "${1:-}" ]]; then
+  images=("${1}")
+else
+  # Capture then split: a here-string of "" would yield one empty element.
+  discovered="$(buildable_images)"
+  [[ -n "${discovered}" ]] && mapfile -t images <<< "${discovered}"
+  [[ ${#images[@]} -gt 0 ]] || die "no images found under images/*/Dockerfile"
+fi
 
 errors=0
-
-if [[ -n "${only_in_dockerfile}" ]]; then
-  echo "ARGs in Dockerfile missing from versions.lock:" >&2
-  echo "  ${only_in_dockerfile//$'\n'/$'\n'  }" >&2
-  errors=1
-fi
-
-if [[ -n "${only_in_lockfile}" ]]; then
-  echo "Keys in versions.lock missing from Dockerfile:" >&2
-  echo "  ${only_in_lockfile//$'\n'/$'\n'  }" >&2
-  errors=1
-fi
-
-if [[ -n "${not_forwarded}" ]]; then
-  echo "ARGs in Dockerfile not forwarded by compose.yaml (reach the build empty):" >&2
-  echo "  ${not_forwarded//$'\n'/$'\n'  }" >&2
-  errors=1
-fi
-
-if [[ -n "${crossed}" ]]; then
-  echo "compose.yaml build args forwarding a differently-named variable:" >&2
-  echo "  ${crossed//$'\n'/$'\n'  }" >&2
-  errors=1
-fi
+for image in "${images[@]}"; do
+  validate_image "${image}" || errors=1
+done
 
 [[ "${errors}" -eq 0 ]] || exit 1

--- a/tests/bats/scripts/lib/validate-lockfile.bats
+++ b/tests/bats/scripts/lib/validate-lockfile.bats
@@ -44,6 +44,21 @@ _make_compose() {
   } > "${IMAGE_DIR}/compose.yaml"
 }
 
+# Add a second image so a bare run has more than one to sweep. `broken` omits
+# the compose arg, which only a sweep can surface when the first image is clean.
+_make_second_image() {
+  local dir="${FAKE_REPO}/images/other-image"
+  mkdir -p "${dir}"
+  printf '%s\n' "FROM scratch" "ARG BAR" > "${dir}/Dockerfile"
+  printf '%s\n' "BAR=2.0.0" > "${dir}/versions.lock"
+  {
+    printf 'services:\n  other-image:\n    build:\n      context: .\n      args:\n'
+    if [[ "${1}" == "good" ]]; then
+      printf '        BAR: ${BAR}\n'
+    fi
+  } > "${dir}/compose.yaml"
+}
+
 # Build a compose.yaml from literal "NAME: value" arg lines, for cases
 # where the forwarded value is deliberately not ${NAME}.
 _make_compose_raw() {
@@ -165,10 +180,50 @@ _make_compose_raw() {
 
 # ── input errors ─────────────────────────────────────────────────────
 
-@test "exits 1 with usage message when the image arg is missing" {
+# ── sweep ────────────────────────────────────────────────────────────
+
+# A bare run covers every image. Scoping is the exception, so these lock down
+# that omitting the argument widens the check rather than narrowing it — the
+# defect being that `make lint` validated only the default image.
+
+@test "validates every image when no image is named" {
+  _make_dockerfile "FROM scratch" "ARG FOO"
+  _make_lockfile "FOO=1.0.0"
+  _make_compose FOO
+  _make_second_image good
+  run "${SCRIPT}"
+  assert_success
+}
+
+@test "a second image's mismatch fails a bare run" {
+  # The first image is clean, so only the sweep can surface this.
+  _make_dockerfile "FROM scratch" "ARG FOO"
+  _make_lockfile "FOO=1.0.0"
+  _make_compose FOO
+  _make_second_image broken
   run "${SCRIPT}"
   assert_failure 1
-  assert_output --partial "usage: validate-lockfile.sh <image>"
+  assert_output --partial "not forwarded by compose.yaml"
+  assert_output --partial "BAR"
+}
+
+@test "naming an image scopes the run to it" {
+  # Same broken second image, skipped because the first is named.
+  _make_dockerfile "FROM scratch" "ARG FOO"
+  _make_lockfile "FOO=1.0.0"
+  _make_compose FOO
+  _make_second_image broken
+  run "${SCRIPT}" test-image
+  assert_success
+}
+
+# ── input errors ─────────────────────────────────────────────────────
+
+@test "exits 1 when no image directory exists at all" {
+  rm -rf "${IMAGE_DIR}"
+  run "${SCRIPT}"
+  assert_failure 1
+  assert_output --partial "no images found"
 }
 
 @test "exits 1 when the Dockerfile is missing" {


### PR DESCRIPTION
## Summary

`lint-lockfile` validated a single image and `IMAGE` defaults to ci-tools, so the bare `make lint` that CI runs left every other image unchecked. That stayed cosmetic until #225 routed the compose-forwarding guard through the same target — the guard that catches an ARG reaching the build empty, where `npm install -g "pkg@"` installs latest while the pin reads as enforced from every side. The docs image sat outside its reach entirely.

Omitting the image now widens the check instead of narrowing it, so a new image is covered the moment it has a Dockerfile rather than when someone remembers to wire it up.

## Related Issues

Fixes #226

## Changes

- `validate-lockfile.sh` sweeps every image; naming one scopes the run
- discovery via a new `buildable_images()` beside the existing enumerators, keyed on the Dockerfile so an image is covered before it earns a release stamp
- `lint` and `lint-lockfile` adopt the target-specific empty `IMAGE` idiom already used by `test-package`, so scoping still survives the hop into the container
- `lint-fix` stops forwarding `IMAGE`, which its targets never read
- prose pass over the comments #225 introduced
- `make test-bats` asks for pretty output when a terminal is attached

## Further Comments

The issue's repro is the regression test, and it now fails as it should: delete `MKDOCS_MATERIAL_VERSION` from `images/docs/compose.yaml` and `make lint` exits non-zero where it previously passed green.

Worth a look in `validate-lockfile.bats`: the case that matters is a second image whose compose is broken while the first is clean, since only a sweep surfaces it. Coverage moved into the fake-repo tests, so it no longer depends on how `make lint` happens to be invoked.

`buildable_images()` keys on the Dockerfile rather than reusing `versioned_images()` or `list-published-images.sh`: both require a release stamp, which would leave a newly added image unvalidated until its first publish.

The prose commit is not purely cosmetic — `LINT_RUNNER` claimed `IMAGE` selects which lockfile `lint-lockfile` validates, which this change falsifies. That sentence is now true only when `IMAGE` is given explicitly.

The bats formatter commit rides along and is unrelated to #226. bats defaults to TAP whatever it is attached to — its `--help` claims a terminal-aware default that the code has not implemented since at least v1.8.0 — so `make test-bats` was never coloured rather than having regressed. The terminal probe now feeds both the container TTY flag and the formatter, so the two cannot disagree; CI has no terminal and its output is unchanged.

Verified with the CI invocations inside the published image (`make lint LINT_RUNNER=make` and `make test-bats BATS_RUNNER=bats`), and confirmed the build dependency stays scoped to the containerized path.
